### PR TITLE
[INJIMOB-3247] deprecate requestCredentialFromTrustedIssuer & requestCredentialByCredentialOffer and use V2 Api from OpenId4Vp library - PDI

### DIFF
--- a/.github/workflows/publish-maven-npm.yml
+++ b/.github/workflows/publish-maven-npm.yml
@@ -8,7 +8,6 @@ on:
         required: false
         default: 'Triggered for inji-vci-client Updates'
         type: string
-
       release_type:
         description: 'Select release type to publish: snapshot or release'
         required: true
@@ -17,12 +16,19 @@ on:
         options:
           - snapshot
           - release
-
       publication_type:
         description: 'Select artifact type to publish: aar, jar, or both (only for release)'
         required: true
         default: both
         type: string
+      group_path:
+        description: 'Select Maven group path'
+        required: true
+        type: choice
+        default: io/inji
+        options:
+          - io/inji
+          - io/mosip
 
 jobs:
   publish-snapshot:
@@ -31,6 +37,7 @@ jobs:
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'vci-client'
+      GROUP_PATH: ${{ inputs.group_path }}
       JAVA_VERSION: 21
       LICENSE_NAME: 'MPL-2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
@@ -48,6 +55,7 @@ jobs:
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'vci-client'
+      GROUP_PATH: ${{ inputs.group_path }}
       JAVA_VERSION: 21
       LICENSE_NAME: 'MPL-2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}

--- a/.github/workflows/publish-maven-npm.yml
+++ b/.github/workflows/publish-maven-npm.yml
@@ -36,7 +36,7 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
-      OSSRH_URL: ${{ secrets.OSSRH_CENTRAL_URL }}
+      OSSRH_URL: ${{ secrets.GRADLE_OSSRH_URL }}
       OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
       OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
       GPG_SECRET: ${{ secrets.GPG_SECRET }}
@@ -57,5 +57,5 @@ jobs:
       OSSRH_URL: ${{ secrets.OSSRH_GRADLE_URL }}
       OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
       OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-      GPG_SECRET: ${{ secrets.GPG_SECRET }}
+      GPG_SECRET: ${{ secrets.GRADLE_OSSRH_URL }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}

--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -12,6 +12,7 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://repo.danubetech.com/repository/maven-public/")
         }
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
         exclusiveContent {
             forRepository {
                 maven {

--- a/kotlin/vci-client/build.gradle.kts
+++ b/kotlin/vci-client/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     testImplementation("org.json:json:20231013")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     implementation("com.squareup.okio:okio:3.6.0")
-    implementation("io.inji:inji-openid4vp-aar:0.7.0-RC1")
+    implementation("io.inji:inji-openid4vp-aar:0.7.0-SNAPSHOT")
     testImplementation(kotlin("test"))
 }
 

--- a/kotlin/vci-client/publish-artifact.gradle
+++ b/kotlin/vci-client/publish-artifact.gradle
@@ -98,7 +98,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "inji-vci-client-aar"
-            version = "0.7.0-RC1"
+            version = "0.7.0-SNAPSHOT"
             archivesBaseName = "${artifactId}-${version}"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/VCIClient.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/VCIClient.kt
@@ -70,6 +70,10 @@ class VCIClient(val traceabilityId: String) {
     }
 
 
+    @Deprecated(
+        message = """This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()""",
+        level = DeprecationLevel.WARNING
+    )
     suspend fun requestCredentialByCredentialOffer(
         credentialOffer: String,
         clientMetadata: ClientMetadata,
@@ -107,6 +111,10 @@ class VCIClient(val traceabilityId: String) {
     }
 
 
+    @Deprecated(
+        message = """This method is deprecated as per the new VCI Client library contract. Use fetchCredentialFromTrustedIssuer()""",
+        level = DeprecationLevel.WARNING
+    )
     suspend fun requestCredentialFromTrustedIssuer(
         credentialIssuer: String,
         credentialConfigurationId: String,
@@ -169,7 +177,7 @@ class VCIClient(val traceabilityId: String) {
         }
     }
 
-    suspend fun fetchCredentialByCredentialOffer(
+    suspend fun fetchCredentialUsingCredentialOffer(
         credentialOffer: String,
         clientMetadata: ClientMetadata,
         getTxCode: TxCodeCallback?,

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
@@ -228,21 +228,9 @@ internal class AuthorizationCodeFlowService(
                 traceabilityId = traceabilityId
             )
         } catch (e: Exception) {
-            if (e.message?.contains("missing_interaction_type") == true || e.message?.contains("No supported interaction types") == true) {
-                logger.info("Falling back to authorization via authorization endpoint as interactive authorization endpoint $endpoint does not support required interaction types.")
-                return obtainAuthorizationCodeViaAuthorizationEndpoint(
-                    authorizationServerMetadata = authorizationServerMetadata,
-                    issuerMetadata = issuerMetadata,
-                    clientMetadata = clientMetadata,
-                    pkceSession = pkceSession,
-                    authorizationMethods = authorizationMethods
-                )
-            } else {
-                throw DownloadFailedException(
-                    "Interactive authorization failed at endpoint $endpoint : ${e.message}"
-                )
-            }
-
+            throw DownloadFailedException(
+                "Interactive authorization failed at endpoint $endpoint : ${e.message}"
+            )
         }
 
         return response.authorizationCode

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
@@ -14,6 +14,6 @@ sealed class AuthorizationMethod(val type: InteractionType) {
     class PresentationDuringIssuance(
         val selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
         val signVerifiablePresentation: SignVerifiablePresentationCallback,
-        val signatureSuite: String? = null,
+        val ldpVpSignatureSuite: String? = null,
     ) : AuthorizationMethod(type = InteractionType.OpenId4VpPresentation)
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
@@ -166,7 +166,7 @@ class InteractiveAuthorizationHandler {
         val authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = presentationMethod.selectCredentialsForPresentation,
             signVerifiablePresentation = presentationMethod.signVerifiablePresentation,
-            signatureSuite = presentationMethod.ldpVpSignatureSuite,
+            ldpVpSignatureSuite = presentationMethod.ldpVpSignatureSuite,
             traceabilityId = traceabilityId
         )
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
@@ -166,7 +166,7 @@ class InteractiveAuthorizationHandler {
         val authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = presentationMethod.selectCredentialsForPresentation,
             signVerifiablePresentation = presentationMethod.signVerifiablePresentation,
-            signatureSuite = presentationMethod.signatureSuite,
+            signatureSuite = presentationMethod.ldpVpSignatureSuite,
             traceabilityId = traceabilityId
         )
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -26,7 +26,7 @@ class PresentationDuringIssuanceAuthorizationMethodService(
     private val signVerifiablePresentation: suspend (
         payload: List<UnsignedVPTokenV2>,
     ) -> List<VPTokenSigningResultV2>,
-    private val signatureSuite: String? = null,
+    private val ldpVpSignatureSuite: String? = null,
     private val traceabilityId: String? = null,
     private val openId4vp: OpenID4VP = OpenID4VP(
         traceabilityId = traceabilityId ?: "",
@@ -98,14 +98,14 @@ class PresentationDuringIssuanceAuthorizationMethodService(
         val hasLdpVc = flattenedFormatEntries.any { (formatType, _) ->
             formatType == FormatType.LDP_VC
         }
-        if (hasLdpVc && signatureSuite == null) {
+        if (hasLdpVc && ldpVpSignatureSuite == null) {
             throw InteractiveAuthorizationException("Missing signature suite for LDP VC")
         }
 
         val unsignedVpTokens = openId4vp.constructUnsignedVPTokenV2(
             verifiableCredentials = selectedCredentials,
             holderId = holderId,
-            signatureSuite = signatureSuite
+            signatureSuite = ldpVpSignatureSuite
         )
 
         val signedVpTokens = signVerifiablePresentation(unsignedVpTokens)

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -2,8 +2,8 @@ package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presen
 
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.AuthorizationMethodService
@@ -24,8 +24,8 @@ import java.util.logging.Logger
 class PresentationDuringIssuanceAuthorizationMethodService(
     private val selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, Map<FormatType, List<Any>>>,
     private val signVerifiablePresentation: suspend (
-        payload: Map<FormatType, UnsignedVPToken>,
-    ) -> Map<FormatType, VPTokenSigningResult>,
+        payload: List<UnsignedVPTokenV2>,
+    ) -> List<VPTokenSigningResultV2>,
     private val signatureSuite: String? = null,
     private val traceabilityId: String? = null,
     private val openId4vp: OpenID4VP = OpenID4VP(
@@ -102,7 +102,7 @@ class PresentationDuringIssuanceAuthorizationMethodService(
             throw InteractiveAuthorizationException("Missing signature suite for LDP VC")
         }
 
-        val unsignedVpTokens = openId4vp.constructUnsignedVPToken(
+        val unsignedVpTokens = openId4vp.constructUnsignedVPTokenV2(
             verifiableCredentials = selectedCredentials,
             holderId = holderId,
             signatureSuite = signatureSuite
@@ -110,7 +110,7 @@ class PresentationDuringIssuanceAuthorizationMethodService(
 
         val signedVpTokens = signVerifiablePresentation(unsignedVpTokens)
 
-        return openId4vp.constructVPResponse(
+        return openId4vp.constructVPResponseV2(
             vpTokenSigningResults = signedVpTokens
         )
     }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
@@ -1,8 +1,8 @@
 package io.mosip.vciclient.constants
 
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.vciclient.token.TokenRequest
 import io.mosip.vciclient.token.TokenResponse
@@ -19,6 +19,6 @@ typealias ProofJwtCallback = (suspend (
 typealias CheckIssuerTrustCallback = (suspend (credentialIssuer: String, issuerDisplay: List<Map<String, Any>>) -> Boolean)
 typealias SelectCredentialsForPresentationCallback = (suspend (ovpRequest: AuthorizationRequest) -> Map<String, Map<FormatType, List<Any>>>)
 typealias SignVerifiablePresentationCallback = suspend (
-    payload: Map<FormatType, UnsignedVPToken>,
-) -> Map<FormatType, VPTokenSigningResult>
+    payload: List<UnsignedVPTokenV2>,
+) -> List<VPTokenSigningResultV2>
 typealias OpenWebPageCallback = (suspend (authorizationUrl: String) -> Map<String, Any>)

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/VCIClientTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/VCIClientTest.kt
@@ -377,7 +377,7 @@ class VCIClientTest {
             )
         } returns mockCredentialResponse
 
-        val result = VCIClient("trace-id").fetchCredentialByCredentialOffer(
+        val result = VCIClient("trace-id").fetchCredentialUsingCredentialOffer(
             credentialOffer = "sample-offer",
             clientMetadata = mockk(),
             getTxCode = getTxCode,
@@ -400,7 +400,7 @@ class VCIClientTest {
         } throws VCIClientException("VCI-999", "known failure")
 
         val ex = assertThrows<VCIClientException> {
-            VCIClient("trace-id").fetchCredentialByCredentialOffer(
+            VCIClient("trace-id").fetchCredentialUsingCredentialOffer(
                 credentialOffer = "sample-offer",
                 clientMetadata = mockk(),
                 getTxCode = getTxCode,

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -10,6 +10,7 @@ import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult
 import io.mosip.openID4VP.constants.FormatType
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.request.AuthorizationRequestData
@@ -53,9 +54,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         // ✅ IMPORTANT: mock positionally (avoid overload + named args mismatch)
         coEvery {
             mockOvp.authenticateVerifier(
-                authRequest = any(),
+                authorizationRequest = any(),
                 any(),
-                any()
+                any(),
             )
         } returns fakeAuthRequest
 
@@ -85,7 +86,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
     fun `should throw when request type is invalid`() = runTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { emptyMap() },
-            signVerifiablePresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
             traceabilityId = "test-trace-id",
         )
 
@@ -114,11 +115,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = {
-                mapOf(
-                    FormatType.LDP_VC to LdpVPTokenSigningResult(
-                        "signed-vp-token",
-                        null,
-                        "Ed25519Signature2020"
+                listOf(
+                    VPTokenSigningResultV2(
+                        signedData = "signed",
                     )
                 )
             },
@@ -132,9 +131,15 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         Assert.assertEquals("success", result.status)
         Assert.assertEquals("auth-code-123", result.authorizationCode)
 
-        coVerify(exactly = 1) { mockOvp.authenticateVerifier(authRequest = any(), any(), any()) }
-        coVerify(exactly = 1) { mockOvp.constructUnsignedVPToken(any(), any(), any()) }
-        coVerify(exactly = 1) { mockOvp.constructVPResponse(any()) }
+        coVerify(exactly = 1) {
+            mockOvp.authenticateVerifier(
+                authorizationRequest = any(),
+                any(),
+                any()
+            )
+        }
+        coVerify(exactly = 1) { mockOvp.constructUnsignedVPTokenV2(any(), any(), any()) }
+        coVerify(exactly = 1) { mockOvp.constructVPResponseV2(any()) }
     }
 
     @Test
@@ -142,7 +147,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { emptyMap() },
-            signVerifiablePresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -159,7 +164,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
     fun `should post VP error response when signatureSuite missing for LDP VC`() = runTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() }, // contains LDP_VC
-            signVerifiablePresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
             ldpVpSignatureSuite = null, // triggers InteractiveAuthorizationException in handlePresentation
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
@@ -185,7 +190,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
-            signVerifiablePresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
             ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
@@ -203,7 +208,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
-            signVerifiablePresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
             ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -122,7 +122,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
                     )
                 )
             },
-            signatureSuite = "Ed25519Signature2020",
+            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -160,7 +160,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() }, // contains LDP_VC
             signVerifiablePresentation = { emptyMap() },
-            signatureSuite = null, // triggers InteractiveAuthorizationException in handlePresentation
+            ldpVpSignatureSuite = null, // triggers InteractiveAuthorizationException in handlePresentation
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -186,7 +186,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyMap() },
-            signatureSuite = "Ed25519Signature2020",
+            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -204,7 +204,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyMap() },
-            signatureSuite = "Ed25519Signature2020",
+            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecated Features**
  * Two legacy credential request entry points marked deprecated; migrate to the updated credential flow.

* **API Changes**
  * Credential fetch API renamed and expanded to accept richer authorization hooks, token/proof handling, issuer-trust checks, and configurable download timeout.
  * Presentation-during-issuance parameter renamed.
  * Verifiable-presentation signing API moved to V2 with list-based payload/response.

* **Bug Fixes**
  * Interactive authorization failures no longer fall back; errors now surface directly.

* **Chores**
  * Publishing workflow and snapshot/release versioning updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->