### PR TITLE
INJIMOB-3574: Removed claims from request body for mso_mdoc request

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -328,10 +328,11 @@ val issuerMetadata = IssuerMetaData(
                         CREDENTIAL_ENDPOINT, 
                         DOWNLOAD_TIMEOUT, 
                         DOC_TYPE,
+                        CLAIMS,
                         CredentialFormat.MSO_MDOC )
 ```
 
->  **Note**: The `claims` parameter is no longer included in the credential request body for `mso_mdoc` format as per the updated OID4VCI specification. Even if `claims` is provided in `IssuerMetaData`, it will be ignored when constructing the credential request for `mso_mdoc` format.
+> ⚠️ **Note**: The `claims` parameter is optional in the OID4VCI specification for `mso_mdoc` format. While `claims` can be provided in `IssuerMetaData`, this implementation does not include `claims` in the credential request body for `mso_mdoc` format.
 
 3. Format: `vc+sd-jwt`
 ```
@@ -371,6 +372,7 @@ val credentialResponse = vciClient.requestCredential(
                         CREDENTIAL_ENDPOINT, 
                         DOWNLOAD_TIMEOUT, 
                         DOC_TYPE,
+                        CLAIMS,
                         CredentialFormat.MSO_MDOC ),
     proofJwt = JWTProof(jwtValue = "sampleProofJwt"),
     accessToken = "sampleAccessToken"

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -328,9 +328,10 @@ val issuerMetadata = IssuerMetaData(
                         CREDENTIAL_ENDPOINT, 
                         DOWNLOAD_TIMEOUT, 
                         DOC_TYPE,
-                        CLAIMS, 
                         CredentialFormat.MSO_MDOC )
 ```
+
+>  **Note**: The `claims` parameter is no longer included in the credential request body for `mso_mdoc` format as per the updated OID4VCI specification. Even if `claims` is provided in `IssuerMetaData`, it will be ignored when constructing the credential request for `mso_mdoc` format.
 
 3. Format: `vc+sd-jwt`
 ```
@@ -370,7 +371,6 @@ val credentialResponse = vciClient.requestCredential(
                         CREDENTIAL_ENDPOINT, 
                         DOWNLOAD_TIMEOUT, 
                         DOC_TYPE,
-                        CLAIMS, 
                         CredentialFormat.MSO_MDOC ),
     proofJwt = JWTProof(jwtValue = "sampleProofJwt"),
     accessToken = "sampleAccessToken"

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/MsoMdocCredentialRequest.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/MsoMdocCredentialRequest.kt
@@ -36,7 +36,6 @@ class MsoMdocCredentialRequest(
 
     private fun generateRequestBody(): RequestBody {
         val credentialRequestBody = MdocCredentialRequestBody(
-            claims = issuerMetadata.claims,
             proof = proof,
             format = this.issuerMetadata.credentialFormat.value,
             doctype = issuerMetadata.doctype!!
@@ -49,7 +48,6 @@ class MsoMdocCredentialRequest(
 private data class MdocCredentialRequestBody(
     val format: String,
     val doctype: String,
-    val claims: Map<String, Any>? = null,
     val proof: Proof,
 ) {
     fun toJson(): String {

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/credential/request/types/MsoMsoMdocCredentialRequestTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/credential/request/types/MsoMsoMdocCredentialRequestTest.kt
@@ -45,7 +45,7 @@ class MsoMsoMdocCredentialRequestTest {
         assertEquals(URI(credentialEndpoint), msoMdocCredentialRequest.url.toUri())
         assertEquals("POST", msoMdocCredentialRequest.method)
         assertEquals(
-            "{\"format\":\"mso_mdoc\",\"doctype\":\"org.iso.18013.5.1.mDL\",\"claims\":{\"org.iso.18013.5.1\":{\"given_name\":{}}},\"proof\":{\"proof_type\":\"jwt\",\"jwt\":\"headerEncoded.payloadEncoded.signature\"}}",
+            "{\"format\":\"mso_mdoc\",\"doctype\":\"org.iso.18013.5.1.mDL\",\"proof\":{\"proof_type\":\"jwt\",\"jwt\":\"headerEncoded.payloadEncoded.signature\"}}",
             getRequestBodyInJsonString(msoMdocCredentialRequest.body!!)
         )
     }


### PR DESCRIPTION
## Removed Claims From Credential Request Body in MSO Mdoc
- Removed the claims from request body for mso_mdoc request 
-  Modified the test files and verified the changes

> Issue Ticket Number and Link
[INJIMOB-3574](https://mosip.atlassian.net/browse/INJIMOB-3574)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified MSO/MDOC credential request payload by removing the claims field so serialized requests only include essential fields.
* **Documentation**
  * Clarified that the claims parameter is optional/excluded for MSO/MDOC requests and updated related examples.
* **Tests**
  * Updated test expectations to match the simplified serialized request body without the claims object.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->