### PR TITLE
chore: renamed credentialdefinition to maintain a consistent format.

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/JwtVcCredentialRequest.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/JwtVcCredentialRequest.kt
@@ -45,7 +45,7 @@ class JwtVcCredentialRequest(
         )
         val request = JwtVcRequestBody(
             format = issuerMetadata.credentialFormat.value,
-            credential_definition = definition,
+            credentialDefinition = definition,
             proof = proof
         ).toJson()
         return request.toRequestBody(APPLICATION_JSON.toMediaTypeOrNull())
@@ -58,7 +58,7 @@ private data class JwtVcCredentialDefinition(
 
 private data class JwtVcRequestBody(
     val format: String,
-    val credential_definition: JwtVcCredentialDefinition,
+    val credentialDefinition: JwtVcCredentialDefinition,
     val proof: Proof
 ) {
     fun toJson(): String = JsonUtils.serialize(this)


### PR DESCRIPTION
What was changed:
Renamed the credential_definition property to credentialDefinition inside JwtVcCredentialRequest.kt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized credential request field naming conventions to follow proper formatting standards, ensuring consistent API behavior and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->