### PR TITLE
[INJIMOB-3701] add logic for missing_interaction_type

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
@@ -8,6 +8,7 @@ import io.mosip.vciclient.authorizationServer.AuthorizationServerMetadata
 import io.mosip.vciclient.authorizationServer.AuthorizationServerResolver
 import io.mosip.vciclient.constants.AuthorizeUserCallback
 import io.mosip.vciclient.constants.Constants
+import io.mosip.vciclient.constants.Constants.MISSING_INTERACTION_TYPE_ERROR
 import io.mosip.vciclient.constants.ProofJwtCallback
 import io.mosip.vciclient.constants.TokenResponseCallback
 import io.mosip.vciclient.credential.request.CredentialRequestExecutor
@@ -206,16 +207,32 @@ internal class AuthorizationCodeFlowService(
 
         return when {
             interactiveEndpoint != null -> {
-                obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
-                    endpoint = interactiveEndpoint,
-                    issuerMetadata = issuerMetadata,
-                    clientMetadata = clientMetadata,
-                    pkceSession = pkceSession,
-                    credentialConfigurationId = credentialConfigurationId,
-                    authorizationMethods = authorizationMethods,
-                    traceabilityId = traceabilityId
-                )
+                try {
+                    obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
+                        endpoint = interactiveEndpoint,
+                        issuerMetadata = issuerMetadata,
+                        clientMetadata = clientMetadata,
+                        pkceSession = pkceSession,
+                        credentialConfigurationId = credentialConfigurationId,
+                        authorizationMethods = authorizationMethods,
+                        traceabilityId = traceabilityId
+                    )
+                } catch (e: DownloadFailedException) {
+                    if (e.serverErrorCode == MISSING_INTERACTION_TYPE_ERROR) {
+                        logger.warning("Interactive authorization failed at $interactiveEndpoint: ${e.message}. Falling back to standard authorization endpoint if available.")
+                        obtainAuthorizationCodeViaAuthorizationEndpoint(
+                            authorizationServerMetadata = authorizationServerMetadata,
+                            issuerMetadata = issuerMetadata,
+                            clientMetadata = clientMetadata,
+                            pkceSession = pkceSession,
+                            authorizationMethods = authorizationMethods
+                        )
+                    }
+                    else
+                        throw e
+                }
             }
+
 
             else -> {
                 obtainAuthorizationCodeViaAuthorizationEndpoint(

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/Constants.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/Constants.kt
@@ -3,6 +3,9 @@ package io.mosip.vciclient.constants
 object Constants {
     const val DEFAULT_NETWORK_TIMEOUT_IN_MILLIS: Long = 10000
     const val CONTENT_TYPE = "Content-Type"
+
     const val APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded"
     const val APPLICATION_JSON = "application/json"
+
+    const val MISSING_INTERACTION_TYPE_ERROR = "missing_interaction_type"
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/networkManager/NetworkManager.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/networkManager/NetworkManager.kt
@@ -117,6 +117,7 @@ object NetworkManager {
             val json = JSONObject(responseBody)
             serverErrorCode = json.optString(ERROR_CODE)
             serverErrorDescription = json.optString(ERROR_DESCRIPTION)
+
         } catch (_: Exception) {
             Logger.getLogger(NetworkManager::class.java.name)
                 .warning("Failed to parse server error response")

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationFlow/AuthorizationcodeFlowserviceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationFlow/AuthorizationcodeFlowserviceTest.kt
@@ -413,6 +413,41 @@ class AuthorizationCodeFlowServiceTest {
     }
 
     @Test
+    fun `should fallback to authorization endpoint when interactive flow returns missing_interaction_type`() = runBlocking {
+        coEvery {
+            anyConstructed<AuthorizationServerResolver>().resolveForAuthCode(any(), any())
+        } returns mockk {
+            every { authorizationEndpoint } returns "https://auth.example.com"
+            every { tokenEndpoint } returns "https://token.example.com"
+            every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+        }
+
+        val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
+        coEvery {
+            mockHandler.handle(any(), any(), any(), any(), any(), any())
+        } returns AuthorizationResponse(
+            authorizationCode = null,
+            status = "error",
+            error = "missing_interaction_type",
+            errorDescription = "interaction type not supported"
+        )
+
+        val result = AuthorizationCodeFlowService(
+            interactiveAuthorizationHandler = mockHandler
+        ).requestCredentials(
+            issuerMetadata = resolvedIssuerMetadata,
+            credentialConfigurationId = credentialConfigurationId,
+            clientMetadata = clientMetadata,
+            getTokenResponse = getTokenResponse,
+            getProofJwt = getProofJwt,
+            jwtProofAlgorithmsSupported = listOf("ES256"),
+            authorizationMethods = listOf(authorizationMethod),
+        )
+
+        assertEquals(mockCredentialResponse, result)
+    }
+
+    @Test
     fun `should wrap interactive authorization client exception details`() = runBlocking {
         coEvery {
             anyConstructed<AuthorizationServerResolver>().resolveForAuthCode(any(), any())
@@ -423,6 +458,7 @@ class AuthorizationCodeFlowServiceTest {
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
+
         coEvery {
             mockHandler.handle(any(), any(), any(), any(), any(), any())
         } throws InteractiveAuthorizationException(
@@ -450,6 +486,46 @@ class AuthorizationCodeFlowServiceTest {
         assertEquals("access_denied", ex.serverErrorCode)
         assertEquals("user cancelled", ex.serverErrorDescription)
         assertTrue(ex.message.contains("Interactive authorization failed at endpoint"))
+    }
+
+    @Test
+    fun `should not fallback and throw when interactive flow fails with different error`() = runBlocking {
+        coEvery {
+            anyConstructed<AuthorizationServerResolver>().resolveForAuthCode(any(), any())
+        } returns mockk {
+            every { authorizationEndpoint } returns "https://auth.example.com"
+            every { tokenEndpoint } returns "https://token.example.com"
+            every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+        }
+
+        val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
+
+        coEvery {
+            mockHandler.handle(any(), any(), any(), any(), any(), any())
+        } returns AuthorizationResponse(
+            authorizationCode = null,
+            status = "error",
+            error = "access_denied",
+            errorDescription = "user denied"
+        )
+
+        val ex = assertThrows<DownloadFailedException> {
+            AuthorizationCodeFlowService(
+                interactiveAuthorizationHandler = mockHandler
+            ).requestCredentials(
+                issuerMetadata = resolvedIssuerMetadata,
+                credentialConfigurationId = credentialConfigurationId,
+                clientMetadata = clientMetadata,
+                getTokenResponse = getTokenResponse,
+                getProofJwt = getProofJwt,
+                jwtProofAlgorithmsSupported = listOf("ES256"),
+                authorizationMethods = listOf(authorizationMethod),
+            )
+        }
+
+        assertTrue(ex.message.contains("code not received"))
+        assertEquals("access_denied", ex.serverErrorCode)
+        assertEquals("user denied", ex.serverErrorDescription)
     }
 
     @Test
@@ -575,6 +651,4 @@ class AuthorizationCodeFlowServiceTest {
 
             assertEquals("auth-code", response["code"])
         }
-
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive authorization now automatically falls back to the alternate authorization path when a specific interaction-type error is encountered, improving reliability and user experience.

* **Tests**
  * Added tests covering the interactive-auth error case and the fallback behavior, plus tests ensuring other interactive errors still surface correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->