### PR TITLE
[INJIMOB-3811] docs: add supported credentials - jwt_vc_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The implementation follows
     - `ldp_vc`
     - `mso_mdoc`
     - `vc+sd-jwt` / `dc+sd-jwt`
+    - `jwt_vc_json`
 - Presentation During Issuance (PDI) support for both download flows (For more details on PDI support, please refer to the [Presentation During Issuance documentation](./doc/presentation-during-issuance-support.md))
 
 > ⚠️ Consumer of this library is responsible for processing and rendering the credential after it is downloaded.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -9,7 +9,7 @@ It supports **Issuer Initiated (Credential Offer)** and **Wallet Initiated (Trus
 Add the following dependency to your `build.gradle` to include the library from **Maven Central**:
 
 ```groovy
-implementation "io.inji:inji-vci-client:0.7.0"
+implementation "io.inji:inji-vci-client:0.8.0"
 ```
 
 ## 🏗️ Construction of VCIClient instance
@@ -94,6 +94,12 @@ mapOf(
   "credentialConfigId-2" to mapOf(
     "format" to "mso_mdoc",
     "doctype" to "org.iso.18013.5.1.mDL"
+  ),
+  "credentialConfigId-3" to mapOf(
+    "format" to "jwt_vc_json",
+    "credential_definition" to mapOf(
+        "type" to listOf("VerifiableCredential", "UniversityDegreeCredential")
+    )
   )
 )
 ```
@@ -548,7 +554,7 @@ AuthorizationMethod.PresentationDuringIssuance(
 - Method: `requestCredential`
 - Request for credential from the providers (credential issuer), and receive the credential back.
 
-> Note: This method is deprecated and will be removed in future releases. Please migrate to `requestCredentialByCredentialOffer()` or `requestCredentialFromTrustedIssuer()`.
+> Note: This method is deprecated and will be removed in future releases. Please migrate to [`fetchCredentialUsingCredentialOffer()`](#fetchcredentialusingcredentialoffer) or [`fetchCredentialFromTrustedIssuer()`](#fetchcredentialfromtrustedissuer).
 
 #### Parameters
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -551,7 +551,7 @@ AuthorizationMethod.PresentationDuringIssuance(
 
 
 ### 3.3 Request Credential
-- Method: `requestCredential`
+- Method: `requestCredential` (deprecated use requestCredentialByCredentialOffer() or requestCredentialFromTrustedIssuer())
 - Request for credential from the providers (credential issuer), and receive the credential back.
 
 > Note: This method is deprecated and will be removed in future releases. Please migrate to [`fetchCredentialUsingCredentialOffer()`](#fetchcredentialusingcredentialoffer) or [`fetchCredentialFromTrustedIssuer()`](#fetchcredentialfromtrustedissuer).

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -12,6 +12,13 @@ Add the following dependency to your `build.gradle` to include the library from 
 implementation "io.inji:inji-vci-client:0.8.0"
 ```
 
+## What's New in 0.8.0
+
+Version `0.8.0` introduces two notable improvements:
+
+- Support for the `jwt_vc_json` credential format across issuer metadata parsing and credential request.
+- Enhanced structured error handling so wallet applications can distinguish between library-level failures and issuer or authorization server error payloads.
+
 ## 🏗️ Construction of VCIClient instance
 
 - The `VCIClient` is constructed with a `traceabilityId` which is used to track the session and traceability of the credential request.
@@ -551,7 +558,7 @@ AuthorizationMethod.PresentationDuringIssuance(
 
 
 ### 3.3 Request Credential
-- Method: `requestCredential` (deprecated use requestCredentialByCredentialOffer() or requestCredentialFromTrustedIssuer())
+- Method: `requestCredential`
 - Request for credential from the providers (credential issuer), and receive the credential back.
 
 > Note: This method is deprecated and will be removed in future releases. Please migrate to [`fetchCredentialUsingCredentialOffer()`](#fetchcredentialusingcredentialoffer) or [`fetchCredentialFromTrustedIssuer()`](#fetchcredentialfromtrustedissuer).
@@ -607,6 +614,18 @@ val issuerMetadata = IssuerMetaData(
                         VCT,
                         CredentialFormat.DC_SD_JWT )
 ```
+
+5. Format: `jwt_vc_json`
+```
+val issuerMetadata = IssuerMetaData(
+                        CREDENTIAL_AUDIENCE,
+                        CREDENTIAL_ENDPOINT,
+                        DOWNLOAD_TIMEOUT,
+                        CREDENTIAL_TYPE,
+                        CredentialFormat.JWT_VC_JSON )
+```
+
+> Note: For `jwt_vc_json`, provide `credentialType` with the credential definition `type` values expected by the issuer. The low-level request API uses these values to build the `credential_definition` object in the credential request.
 #### Returns
 
 An instance of `CredentialResponse` containing:
@@ -661,19 +680,113 @@ The following methods are deprecated and will be removed in future releases. Ple
 ## 🛑 Error Handling
 
 All exceptions thrown by the library are subclasses of `VCIClientException`.  
-They carry structured error codes like `VCI-001`, `VCI-002` etc., to help consumers identify and recover from failures.
+They carry structured fields that help consumers identify whether the failure came from the library itself, a wrapped library exception, or an upstream server response.
+
+### `VCIClientException` fields
+
+| Field                    | Type      | Meaning |
+|--------------------------|-----------|---------|
+| `code`                   | `String`  | The library-defined error code for the exception being thrown to the consumer. |
+| `message`                | `String`  | Human-readable summary of the failure, ready for logging or diagnostics. |
+| `sourceErrorCode`        | `String?` | The root `VCI-*` code from the underlying cause when the library wraps another `VCIClientException`. |
+| `serverErrorCode`        | `String?` | The issuer or authorization server `error` value when the remote service returned a structured OAuth/OID4VCI style error response. |
+| `serverErrorDescription` | `String?` | The upstream `error_description` value when available. If the response body is not parseable JSON, the raw response body may be propagated here for diagnostics. |
+
+### Old vs new error handling
+
+Before `0.8.0`, consumers could reliably use only:
+
+- `code` to identify the immediate library error category.
+- `message` for a human-readable summary.
+
+In `0.8.0`, the error model is more expressive:
+
+- `code` still identifies the current exception returned to the caller.
+- `sourceErrorCode` preserves the deeper `VCI-*` code when the current exception wraps another library exception.
+- `serverErrorCode` captures the upstream server `error` field when present.
+- `serverErrorDescription` captures the upstream `error_description`, or the raw error body when structured parsing is not possible.
+
+This means consumers can now distinguish between:
+
+- a library wrapper error exposed at the public API boundary,
+- the original underlying library failure,
+- and a server-originated error payload returned by the issuer or authorization server.
+
+#### Comparison
+
+| Aspect | Before `0.8.0` | From `0.8.0` |
+|--------|----------------|--------------|
+| Library error code | Available through `code` | Available through `code` |
+| Human-readable message | Available through `message` | Available through `message` |
+| Root cause library code after wrapping | Not preserved explicitly | Available through `sourceErrorCode` |
+| Upstream OAuth / issuer `error` value | Usually lost or only visible in message text | Available through `serverErrorCode` |
+| Upstream `error_description` | Usually lost or only visible in message text | Available through `serverErrorDescription` |
+| Consumer-side recovery decisions | Mostly based on `code` and message parsing | Can be based on `code`, `sourceErrorCode`, and upstream server fields |
+
+#### Impact on consumers
+
+- If your integration only switches on `code`, it will continue to work.
+- If you previously parsed `message` to infer server-side failures, you should move that logic to `serverErrorCode` and `serverErrorDescription`.
+- If you want better observability, log all four fields: `code`, `sourceErrorCode`, `serverErrorCode`, and `serverErrorDescription`.
+- If you want better retry and UX decisions, use `code` for the top-level category and `serverErrorCode` for server-specific remediation.
+
+### What each field means for consumers
+
+- Use `code` for primary client-side branching, telemetry dimensions, and product analytics.
+- Use `sourceErrorCode` when `code` represents a wrapper exception and you need the more specific underlying failure category.
+- Use `serverErrorCode` to decide whether a failure is recoverable through user action, such as re-authentication, retry, or correcting a request.
+- Use `serverErrorDescription` for logs, support tooling, and developer diagnostics. Avoid showing it directly to end users without sanitization because it may contain server-specific text.
+
+Some public API methods may wrap an internal `VCIClientException` into another `VCIClientException` before rethrowing it. This improves consistency at the API boundary without losing the root cause.
+
+Example:
+
+- `getIssuerMetadata()` may throw `VCI-010` at the API boundary.
+- `sourceErrorCode` may still contain `VCI-009` if the underlying failure was an issuer metadata fetch error.
+- `serverErrorCode` may contain a remote value such as `invalid_token` if the upstream endpoint returned it.
+
+### Recommended consumer handling
+
+```kotlin
+try {
+    val credentialResponse = vciClient.fetchCredentialUsingCredentialOffer(
+        credentialOffer = credentialOffer,
+        clientMetadata = clientMetadata,
+        getTxCode = getTxCode,
+        authorizations = authorizations,
+        getTokenResponse = getTokenResponse,
+        getProofJwt = getProofJwt
+    )
+} catch (e: VCIClientException) {
+    logger.error(
+        "VCI request failed. code=${e.code}, source=${e.sourceErrorCode}, " +
+            "serverCode=${e.serverErrorCode}, serverDescription=${e.serverErrorDescription}, " +
+            "message=${e.message}"
+    )
+
+    when (e.code) {
+        "VCI-007" -> showRetryMessage()
+        "VCI-003" -> triggerTokenRefresh()
+        "VCI-011" -> showAuthorizationFailure()
+        else -> showGenericFailure()
+    }
+}
+```
+
+### Error code reference
 
 | Code    | Exception Type                          | Description                                                                                              |
 |---------|-----------------------------------------|----------------------------------------------------------------------------------------------------------|
 | VCI-001 | `AuthorizationServerDiscoveryException` | Failed to discover authorization server                                                                  |
-| VCI-002 | `DownloadFailedException`               | Failed to download Credential issuer                                                                     |
+| VCI-002 | `DownloadFailedException`               | Failed to download credential                                                                            |
 | VCI-003 | `InvalidAccessTokenException`           | Access token is invalid                                                                                  |
 | VCI-004 | `InvalidDataProvidedException`          | Required details not provided                                                                            |
-| VCI-005 | `InvalidPublicKeyException`             | Invalid public key passed metadata                                                                       |
+| VCI-005 | `InvalidPublicKeyException`             | Invalid public key passed                                                                                |
 | VCI-006 | `NetworkRequestFailedException`         | Network request failed                                                                                   |
 | VCI-007 | `NetworkRequestTimeoutException`        | Network request timed-out                                                                                |
-| VCI-008 | `OfferFetchFailedException`             | Failed  to fetch credentialOffer                                                                         |
+| VCI-008 | `CredentialOfferFetchFailedException`   | Failed to fetch credential offer                                                                         |
 | VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata                                                                           |
+| VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                |
 | VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `jwt_vc_json` credential format and "What's New in 0.8.0"
  * Updated Maven dependency to 0.8.0
  * Added JWT VC JSON credential configuration example and IssuerMetaData guidance (credentialType must match issuer)
  * Updated deprecation guidance to new fetch APIs
  * Rewrote error-handling docs with expanded exception fields, try/catch snippet, revised error-table entries (added VCI-010)
  * Minor formatting fix (trailing newline)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->