### PR TITLE
fix(android): make proofs callback public and old proofjwt callback  internal

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
@@ -11,12 +11,12 @@ import io.mosip.vciclient.token.TokenResponse
 typealias TxCodeCallback = (suspend (inputMode: String?, description: String?, length: Int?) -> String)
 typealias AuthorizeUserCallback = (suspend (authorizationUrl: String) -> String)
 typealias TokenResponseCallback = suspend (tokenRequest: TokenRequest) -> TokenResponse
-typealias ProofJwtCallback = (suspend (
+internal typealias ProofJwtCallback = (suspend (
     credentialIssuer: String,
     cNonce: String?,
     proofSigningAlgorithmsSupported: List<String>
 ) -> String)
-internal typealias ProofsCallback = (suspend (
+typealias ProofsCallback = (suspend (
     credentialIssuer: String,
     nonce: String?,
     proofSigningAlgorithmsSupported: List<String>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal API visibility for improved library structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->