### PR TITLE
chore: update OVP library version

### DIFF
--- a/kotlin/vci-client/build.gradle.kts
+++ b/kotlin/vci-client/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     testImplementation("org.json:json:20231013")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     implementation("com.squareup.okio:okio:3.6.0")
-    implementation("io.inji:inji-openid4vp-aar:0.7.0")
+    implementation("io.inji:inji-openid4vp-aar:1.0.0-SNAPSHOT")
     testImplementation(kotlin("test"))
 }
 

--- a/kotlin/vci-client/publish-artifact.gradle
+++ b/kotlin/vci-client/publish-artifact.gradle
@@ -98,7 +98,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "inji-vci-client-aar"
-            version = "0.8.0-SNAPSHOT"
+            version = "1.0.0-SNAPSHOT"
             archivesBaseName = "${artifactId}-${version}"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
@@ -13,7 +13,6 @@ sealed class AuthorizationMethod(val type: InteractionType) {
 
     class PresentationDuringIssuance(
         val selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
-        val signVerifiablePresentation: SignVerifiablePresentationCallback,
-        val ldpVpSignatureSuite: String? = null,
+        val signVerifiablePresentation: SignVerifiablePresentationCallback
     ) : AuthorizationMethod(type = InteractionType.OpenId4VpPresentation)
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
@@ -1,5 +1,6 @@
 package io.mosip.vciclient.authorizationCodeFlow
 
+import io.mosip.openID4VP.authorizationRequest.WalletConfig
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.InteractionType
 import io.mosip.vciclient.constants.SelectCredentialsForPresentationCallback
 import io.mosip.vciclient.constants.OpenWebPageCallback
@@ -12,6 +13,7 @@ sealed class AuthorizationMethod(val type: InteractionType) {
     ) : AuthorizationMethod(InteractionType.RedirectToWeb)
 
     class PresentationDuringIssuance(
+        val openid4vpWalletConfig: WalletConfig = WalletConfig(),
         val selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
         val signVerifiablePresentation: SignVerifiablePresentationCallback
     ) : AuthorizationMethod(type = InteractionType.OpenId4VpPresentation)

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
@@ -181,6 +181,7 @@ class InteractiveAuthorizationHandler {
         val authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = presentationMethod.selectCredentialsForPresentation,
             signVerifiablePresentation = presentationMethod.signVerifiablePresentation,
+            openid4vpWalletConfig = presentationMethod.openid4vpWalletConfig,
             traceabilityId = traceabilityId
         )
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
@@ -60,9 +60,7 @@ class InteractiveAuthorizationHandler {
                 )
             }
 
-            val type = extractTypeAndThrowIfError(response.body)
-
-            when (type) {
+            when (val type = extractTypeAndThrowIfError(response.body)) {
                 InteractionType.OpenId4VpPresentation.value ->
                     handlePresentationInteraction(
                         response.body,
@@ -183,7 +181,6 @@ class InteractiveAuthorizationHandler {
         val authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = presentationMethod.selectCredentialsForPresentation,
             signVerifiablePresentation = presentationMethod.signVerifiablePresentation,
-            ldpVpSignatureSuite = presentationMethod.ldpVpSignatureSuite,
             traceabilityId = traceabilityId
         )
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -23,20 +23,38 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.logging.Logger
 
-class PresentationDuringIssuanceAuthorizationMethodService(
-    private val selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, List<Credential>>,
+class PresentationDuringIssuanceAuthorizationMethodService : AuthorizationMethodService {
+    private val selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, List<Credential>>
     private val signVerifiablePresentation: suspend (
         payload: List<UnsignedVPToken>,
-    ) -> List<VPTokenSigningResult>,
-    private val traceabilityId: String? = null,
-    private val openId4vp: OpenID4VP = OpenID4VP(
-        traceabilityId = traceabilityId ?: "",
-        walletConfig = WalletConfig()
-    ),
-) : AuthorizationMethodService {
+    ) -> List<VPTokenSigningResult>
+    private val traceabilityId: String?
+    val openid4vpWalletConfig: WalletConfig
+    private val openId4vp: OpenID4VP
 
-    private val logTag = Util.getLogTag(javaClass.simpleName, traceabilityId)
-    private val logger = Logger.getLogger(logTag)
+    private val logTag: String
+    private val logger: Logger
+
+    constructor(
+        selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, List<Credential>>,
+        signVerifiablePresentation: suspend (
+            payload: List<UnsignedVPToken>,
+        ) -> List<VPTokenSigningResult>,
+        traceabilityId: String? = null,
+        openid4vpWalletConfig: WalletConfig,
+        openId4vp: OpenID4VP? = null,
+    ) {
+        this.selectCredentialsForPresentation = selectCredentialsForPresentation
+        this.signVerifiablePresentation = signVerifiablePresentation
+        this.traceabilityId = traceabilityId
+        this.openid4vpWalletConfig = openid4vpWalletConfig
+        this.openId4vp = openId4vp ?: OpenID4VP(
+            traceabilityId = traceabilityId ?: "",
+            walletConfig = openid4vpWalletConfig
+        )
+        this.logTag = Util.getLogTag(javaClass.simpleName, traceabilityId)
+        this.logger = Logger.getLogger(logTag)
+    }
 
     override fun type(): String = InteractionType.OpenId4VpPresentation.value
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -2,6 +2,7 @@ package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presen
 
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
+import io.mosip.openID4VP.authorizationRequest.WalletConfig
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
@@ -29,7 +30,8 @@ class PresentationDuringIssuanceAuthorizationMethodService(
     ) -> List<VPTokenSigningResult>,
     private val traceabilityId: String? = null,
     private val openId4vp: OpenID4VP = OpenID4VP(
-        traceabilityId = traceabilityId ?: ""
+        traceabilityId = traceabilityId ?: "",
+        walletConfig = WalletConfig()
     ),
 ) : AuthorizationMethodService {
 
@@ -87,7 +89,7 @@ class PresentationDuringIssuanceAuthorizationMethodService(
 
 
     private fun validatePresentationRequest(request: Map<String, Any>): AuthorizationRequest {
-        return openId4vp.authenticateVerifier(request, emptyList(), false)
+        return openId4vp.authenticateVerifier(request)
     }
 
     private suspend fun handlePresentation(vpRequest: AuthorizationRequest): Map<String, Any> {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -2,10 +2,10 @@ package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presen
 
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
-import io.mosip.openID4VP.constants.FormatType
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions
+import io.mosip.openID4VP.wallet.Credential
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.AuthorizationMethodService
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.InteractionType
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.request.AuthorizationRequestData
@@ -23,15 +23,13 @@ import kotlinx.coroutines.withContext
 import java.util.logging.Logger
 
 class PresentationDuringIssuanceAuthorizationMethodService(
-    private val selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, Map<FormatType, List<Any>>>,
+    private val selectCredentialsForPresentation: suspend (ovpRequest: AuthorizationRequest) -> Map<String, List<Credential>>,
     private val signVerifiablePresentation: suspend (
-        payload: List<UnsignedVPTokenV2>,
-    ) -> List<VPTokenSigningResultV2>,
-    private val ldpVpSignatureSuite: String? = null,
+        payload: List<UnsignedVPToken>,
+    ) -> List<VPTokenSigningResult>,
     private val traceabilityId: String? = null,
     private val openId4vp: OpenID4VP = OpenID4VP(
-        traceabilityId = traceabilityId ?: "",
-        walletMetadata = null
+        traceabilityId = traceabilityId ?: ""
     ),
 ) : AuthorizationMethodService {
 
@@ -102,46 +100,15 @@ class PresentationDuringIssuanceAuthorizationMethodService(
             )
         }
 
-        val holderId = extractHolderIdForLdpVc(selectedCredentials)
-
-        val flattenedFormatEntries = selectedCredentials.values.flatMap { formatMap ->
-            formatMap.map { it.key to it.value }
-        }
-        val hasLdpVc = flattenedFormatEntries.any { (formatType, _) ->
-            formatType == FormatType.LDP_VC
-        }
-        if (hasLdpVc && ldpVpSignatureSuite == null) {
-            throw InteractiveAuthorizationException("Missing signature suite for LDP VC")
-        }
-
-        val unsignedVpTokens = openId4vp.constructUnsignedVPTokenV2(
-            verifiableCredentials = selectedCredentials,
-            holderId = holderId,
-            signatureSuite = ldpVpSignatureSuite
+        val unsignedVpTokens = openId4vp.constructUnsignedVPToken(
+            selectedCredentials = selectedCredentials,
         )
 
         val signedVpTokens = signVerifiablePresentation(unsignedVpTokens)
 
-        return openId4vp.constructVPResponseV2(
+        return openId4vp.constructVPResponse(
             vpTokenSigningResults = signedVpTokens
         )
-    }
-
-    private fun extractHolderIdForLdpVc(
-        credentialsMap: Map<String, Map<FormatType, List<Any>>>
-    ): String? {
-        return credentialsMap.values.firstNotNullOfOrNull { formatMap ->
-            val ldpVc = formatMap[FormatType.LDP_VC]?.firstOrNull()
-            val vc = when (ldpVc) {
-                is String -> JsonUtils.deserialize(ldpVc, Map::class.java)
-                is Map<*, *> -> ldpVc
-                else -> null
-            }
-            val credentialSubject = vc?.get("credentialSubject") as? Map<*, *>
-            credentialSubject?.get("id") as? String
-        }
-            ?.trimEnd('=')
-            ?.plus("#0")
     }
 
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt
@@ -1,9 +1,9 @@
 package io.mosip.vciclient.constants
 
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV2
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
-import io.mosip.openID4VP.constants.FormatType
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.wallet.Credential
 import io.mosip.vciclient.proof.CredentialRequestProofs
 import io.mosip.vciclient.token.TokenRequest
 import io.mosip.vciclient.token.TokenResponse
@@ -23,8 +23,8 @@ typealias ProofsCallback = (suspend (
 ) -> CredentialRequestProofs)
 
 typealias CheckIssuerTrustCallback = (suspend (credentialIssuer: String, issuerDisplay: List<Map<String, Any>>) -> Boolean)
-typealias SelectCredentialsForPresentationCallback = (suspend (ovpRequest: AuthorizationRequest) -> Map<String, Map<FormatType, List<Any>>>)
+typealias SelectCredentialsForPresentationCallback = (suspend (ovpRequest: AuthorizationRequest) -> Map<String, List<Credential>>)
 typealias SignVerifiablePresentationCallback = suspend (
-    payload: List<UnsignedVPTokenV2>,
-) -> List<VPTokenSigningResultV2>
+    payload: List<UnsignedVPToken>,
+) -> List<VPTokenSigningResult>
 typealias OpenWebPageCallback = (suspend (authorizationUrl: String) -> Map<String, Any>)

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
@@ -5,16 +5,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.mosip.openID4VP.OpenID4VP
-import io.mosip.openID4VP.authorizationRequest.AuthorizationPresentationExchangeRequest
-import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
-import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
-import io.mosip.openID4VP.wallet.Credential
 import io.mosip.vciclient.authorizationCodeFlow.AuthorizationMethod
 import io.mosip.vciclient.authorizationCodeFlow.clientMetadata.ClientMetadata
+import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance.PresentationDuringIssuanceAuthorizationMethodService
+import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance.PresentationDuringIssuanceRequestData
+import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.response.AuthorizationResponse
 import io.mosip.vciclient.exception.InteractiveAuthorizationException
 import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
@@ -25,6 +22,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import android.util.Base64
 import kotlin.test.assertFailsWith
 
 
@@ -62,53 +60,14 @@ class InteractiveAuthorizationHandlerTest {
     }
 
 
-//    @Test
+    @Test
     fun `should handle OpenID4VP presentation interaction successfully`() = runTest {
         val responseBody = mockPresentationInteractionResponse
 
-        // Create callbacks that return valid responses
-        val selectCredentialsForPresentation: suspend (AuthorizationRequest) -> Map<String, List<Credential>> = {
-            mapOf("id1" to listOf(mockk(relaxed = true)))
-        }
-        val signVerifiablePresentation: suspend (List<UnsignedVPToken>) -> List<VPTokenSigningResult> = {
-            listOf(mockk(relaxed = true))
-        }
+        // OpenID4VP constructor uses android.util.Base64; stub it in JVM unit tests.
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any<ByteArray>(), any()) } returns "b64"
 
-        val presentationMethod = AuthorizationMethod.PresentationDuringIssuance(
-            selectCredentialsForPresentation = selectCredentialsForPresentation,
-            signVerifiablePresentation = signVerifiablePresentation,
-        )
-
-        // Mock OpenID4VP
-        mockkConstructor(OpenID4VP::class)
-        val fakeAuthRequest = AuthorizationPresentationExchangeRequest(
-            clientId = "https://trusted.com",
-            redirectUri = "",
-            responseType = "",
-            state = "",
-            nonce = "",
-            responseMode = "",
-            responseUri = null,
-            walletNonce = "",
-            clientMetadata = null,
-            presentationDefinition = PresentationDefinition(
-                id = "pd-id",
-                inputDescriptors = emptyList()
-            )
-        )
-        coEvery {
-            anyConstructed<OpenID4VP>().authenticateVerifier(any<Map<String, Any>>())
-        } returns fakeAuthRequest
-
-        coEvery {
-            anyConstructed<OpenID4VP>().constructUnsignedVPToken(any())
-        } returns listOf(mockk(relaxed = true))
-
-        coEvery {
-            anyConstructed<OpenID4VP>().constructVPResponse(any())
-        } returns mapOf("vp_token" to "signed-vp-token")
-
-        // Mock NetworkManager to return different responses for different calls
         every {
             NetworkManager.sendRequest(
                 url = endpoint,
@@ -116,14 +75,20 @@ class InteractiveAuthorizationHandlerTest {
                 bodyParams = any(),
                 headers = any()
             )
-        } returns NetworkResponse(responseBody, null) andThen NetworkResponse(
-            """{
-              "status":"success",
-              "code":"auth-code-123",
-              "auth_session":"auth-session"
-            }""",
-            null
+        } returns NetworkResponse(responseBody, null)
+
+        val expectedAuthResponse = mockk<AuthorizationResponse>()
+
+        val presentationMethod = AuthorizationMethod.PresentationDuringIssuance(
+            selectCredentialsForPresentation = mockk(relaxed = true),
+            signVerifiablePresentation = mockk(relaxed = true),
         )
+
+        mockkConstructor(PresentationDuringIssuanceAuthorizationMethodService::class)
+        coEvery {
+            anyConstructed<PresentationDuringIssuanceAuthorizationMethodService>()
+                .authorizeUser(any<PresentationDuringIssuanceRequestData>())
+        } returns expectedAuthResponse
 
         val result = handler.handle(
             endpoint = endpoint,
@@ -134,7 +99,7 @@ class InteractiveAuthorizationHandlerTest {
             traceabilityId = "demo"
         )
 
-        assert(result != null)
+        assertEquals(expectedAuthResponse, result)
     }
 
 
@@ -218,7 +183,7 @@ class InteractiveAuthorizationHandlerTest {
             NetworkManager.sendRequest(any(), any(), any(), any())
         } returns NetworkResponse(responseBody, null)
 
-         assertFailsWith<InteractiveAuthorizationException> {
+        assertFailsWith<InteractiveAuthorizationException> {
             handler.handle(
                 endpoint,
                 clientMetadata,

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
@@ -6,11 +6,15 @@ import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mosip.openID4VP.OpenID4VP
+import io.mosip.openID4VP.authorizationRequest.AuthorizationPresentationExchangeRequest
+import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
+import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
+import io.mosip.openID4VP.wallet.Credential
 import io.mosip.vciclient.authorizationCodeFlow.AuthorizationMethod
 import io.mosip.vciclient.authorizationCodeFlow.clientMetadata.ClientMetadata
-import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance.PresentationDuringIssuanceRequestData
-import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance.PresentationDuringIssuanceAuthorizationMethodService
-import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.response.AuthorizationResponse
 import io.mosip.vciclient.exception.InteractiveAuthorizationException
 import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
@@ -58,10 +62,53 @@ class InteractiveAuthorizationHandlerTest {
     }
 
 
-    @Test
+//    @Test
     fun `should handle OpenID4VP presentation interaction successfully`() = runTest {
         val responseBody = mockPresentationInteractionResponse
 
+        // Create callbacks that return valid responses
+        val selectCredentialsForPresentation: suspend (AuthorizationRequest) -> Map<String, List<Credential>> = {
+            mapOf("id1" to listOf(mockk(relaxed = true)))
+        }
+        val signVerifiablePresentation: suspend (List<UnsignedVPToken>) -> List<VPTokenSigningResult> = {
+            listOf(mockk(relaxed = true))
+        }
+
+        val presentationMethod = AuthorizationMethod.PresentationDuringIssuance(
+            selectCredentialsForPresentation = selectCredentialsForPresentation,
+            signVerifiablePresentation = signVerifiablePresentation,
+        )
+
+        // Mock OpenID4VP
+        mockkConstructor(OpenID4VP::class)
+        val fakeAuthRequest = AuthorizationPresentationExchangeRequest(
+            clientId = "https://trusted.com",
+            redirectUri = "",
+            responseType = "",
+            state = "",
+            nonce = "",
+            responseMode = "",
+            responseUri = null,
+            walletNonce = "",
+            clientMetadata = null,
+            presentationDefinition = PresentationDefinition(
+                id = "pd-id",
+                inputDescriptors = emptyList()
+            )
+        )
+        coEvery {
+            anyConstructed<OpenID4VP>().authenticateVerifier(any(), any(), any())
+        } returns fakeAuthRequest
+
+        coEvery {
+            anyConstructed<OpenID4VP>().constructUnsignedVPToken(any())
+        } returns listOf(mockk(relaxed = true))
+
+        coEvery {
+            anyConstructed<OpenID4VP>().constructVPResponse(any())
+        } returns mapOf("vp_token" to "signed-vp-token")
+
+        // Mock NetworkManager to return different responses for different calls
         every {
             NetworkManager.sendRequest(
                 url = endpoint,
@@ -69,20 +116,14 @@ class InteractiveAuthorizationHandlerTest {
                 bodyParams = any(),
                 headers = any()
             )
-        } returns NetworkResponse(responseBody, null)
-
-        val expectedAuthResponse = mockk<AuthorizationResponse>()
-
-        val presentationMethod = AuthorizationMethod.PresentationDuringIssuance(
-            selectCredentialsForPresentation = mockk(relaxed = true),
-            signVerifiablePresentation = mockk(relaxed = true),
+        } returns NetworkResponse(responseBody, null) andThen NetworkResponse(
+            """{
+              "status":"success",
+              "code":"auth-code-123",
+              "auth_session":"auth-session"
+            }""",
+            null
         )
-
-        mockkConstructor(PresentationDuringIssuanceAuthorizationMethodService::class)
-        coEvery {
-            anyConstructed<PresentationDuringIssuanceAuthorizationMethodService>()
-                .authorizeUser(any<PresentationDuringIssuanceRequestData>())
-        } returns expectedAuthResponse
 
         val result = handler.handle(
             endpoint = endpoint,
@@ -93,7 +134,7 @@ class InteractiveAuthorizationHandlerTest {
             traceabilityId = "demo"
         )
 
-        assertEquals(expectedAuthResponse, result)
+        assert(result != null)
     }
 
 

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
@@ -97,7 +97,7 @@ class InteractiveAuthorizationHandlerTest {
             )
         )
         coEvery {
-            anyConstructed<OpenID4VP>().authenticateVerifier(any(), any(), any())
+            anyConstructed<OpenID4VP>().authenticateVerifier(any<Map<String, Any>>())
         } returns fakeAuthRequest
 
         coEvery {

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -7,12 +7,13 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
 import io.mosip.openID4VP.OpenID4VP
+import io.mosip.openID4VP.authorizationRequest.AuthorizationPresentationExchangeRequest
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
-import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResultV2
-import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
 import io.mosip.openID4VP.constants.FormatType
+import io.mosip.openID4VP.wallet.Credential
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.request.AuthorizationRequestData
 import io.mosip.vciclient.exception.InteractiveAuthorizationException
 import io.mosip.vciclient.networkManager.NetworkManager
@@ -34,7 +35,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         mockOvp = mockk(relaxed = true)
 
-        fakeAuthRequest = AuthorizationRequest(
+        fakeAuthRequest = AuthorizationPresentationExchangeRequest(
             clientId = "https://trusted.com",
             redirectUri = "",
             responseType = "",
@@ -44,7 +45,6 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
             responseUri = null,
             walletNonce = "",
             clientMetadata = null,
-            clientIdScheme = null,
             presentationDefinition = PresentationDefinition(
                 id = "pd-id",
                 inputDescriptors = emptyList()
@@ -73,11 +73,11 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
     private fun validCredentialMap() =
         mapOf(
-            "id1" to mapOf(
-                FormatType.LDP_VC to listOf(
-                    """{ "credentialSubject": { "id": "did:example:123" } }"""
-                )
-            )
+            "id1" to listOf(io.mosip.openID4VP.wallet.Credential(
+                format = FormatType.LDP_VC,
+                data = """{ "credentialSubject": { "id": "did:example:123" } }""",
+                credentialId = "c1"
+            ))
         )
 
     // ------------------------------------------------------------------------
@@ -97,8 +97,8 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
     @Test
     fun `should successfully authorize and return success response`() = runTest {
-        coEvery { mockOvp.constructUnsignedVPToken(any(), any(), any()) } returns mapOf(
-            FormatType.LDP_VC to UnsignedLdpVPToken("unsigned")
+        coEvery { mockOvp.constructUnsignedVPToken(any()) } returns listOf(
+            UnsignedVPToken(FormatType.LDP_VC, "k1","ES256", "unsigned".toByteArray())
         )
 
         coEvery { mockOvp.constructVPResponse(any()) } returns mapOf("vp_token" to "signed")
@@ -116,12 +116,11 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = {
                 listOf(
-                    VPTokenSigningResultV2(
-                        signedData = "signed",
+                    VPTokenSigningResult(
+                        signedData = "signed".toByteArray(),
                     )
                 )
             },
-            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -138,8 +137,8 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
                 any()
             )
         }
-        coVerify(exactly = 1) { mockOvp.constructUnsignedVPTokenV2(any(), any(), any()) }
-        coVerify(exactly = 1) { mockOvp.constructVPResponseV2(any()) }
+        coVerify(exactly = 1) { mockOvp.constructUnsignedVPToken(any()) }
+        coVerify(exactly = 1) { mockOvp.constructVPResponse(any()) }
     }
 
     @Test
@@ -156,27 +155,10 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         verify(exactly = 1) { NetworkManager.sendRequest(any(), any(), any(), any()) }
 
-        coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any(), any(), any()) }
+        coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any()) }
         coVerify(exactly = 0) { mockOvp.constructVPResponse(any()) }
     }
-
-    @Test
-    fun `should post VP error response when signatureSuite missing for LDP VC`() = runTest {
-        val handler = PresentationDuringIssuanceAuthorizationMethodService(
-            selectCredentialsForPresentation = { validCredentialMap() }, // contains LDP_VC
-            signVerifiablePresentation = { emptyList() },
-            ldpVpSignatureSuite = null, // triggers InteractiveAuthorizationException in handlePresentation
-            openId4vp = mockOvp,
-            traceabilityId = "test-trace-id"
-        )
-
-        handler.authorizeUser(validRequest())
-
-        verify(exactly = 1) { NetworkManager.sendRequest(any(), any(), any(), any()) }
-
-        coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any(), any(), any()) }
-    }
-
+    
     @Test
     fun `should throw when network post fails`() = runTest {
         every {
@@ -191,7 +173,6 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyList() },
-            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )
@@ -209,7 +190,6 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyList() },
-            ldpVpSignatureSuite = "Ed25519Signature2020",
             openId4vp = mockOvp,
             traceabilityId = "test-trace-id"
         )

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import io.mosip.openID4VP.OpenID4VP
 import io.mosip.openID4VP.authorizationRequest.AuthorizationPresentationExchangeRequest
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest
+import io.mosip.openID4VP.authorizationRequest.WalletConfig
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult
@@ -58,6 +59,10 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
             )
         } returns fakeAuthRequest
 
+        coEvery { mockOvp.constructUnsignedVPToken(any()) } returns emptyList()
+        coEvery { mockOvp.constructVPResponse(any()) } returns emptyMap()
+        every { mockOvp.constructErrorInfo(any()) } returns mapOf("error" to "access_denied")
+
         every { NetworkManager.sendRequest(any(), any(), any(), any()) } returns
                 NetworkResponse("""{"status":"error"}""", null)
     }
@@ -82,17 +87,40 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
     // ------------------------------------------------------------------------
 
+
     @Test
     fun `should throw when request type is invalid`() = runTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { emptyMap() },
             signVerifiablePresentation = { emptyList() },
-            openId4vp = mockOvp,
+            openid4vpWalletConfig = WalletConfig(),
             traceabilityId = "test-trace-id",
+            openId4vp = mockOvp,
         )
 
         assertThrows<InteractiveAuthorizationException> {
             handler.authorizeUser(AuthorizationRequestData())
+        }
+    }
+
+    @Test
+    fun `should use injected OVP instance`() = runTest {
+        val injectedOvp = mockk<OpenID4VP>(relaxed = true)
+        coEvery { injectedOvp.authenticateVerifier(any<Map<String, Any>>()) } returns fakeAuthRequest
+        every { injectedOvp.constructErrorInfo(any()) } returns mapOf("error" to "access_denied")
+
+        val handler = PresentationDuringIssuanceAuthorizationMethodService(
+            selectCredentialsForPresentation = { emptyMap() },
+            signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(isPresentationDefinitionUriSupported = false),
+            traceabilityId = "test-trace-id",
+            openId4vp = injectedOvp,
+        )
+
+        handler.authorizeUser(validRequest())
+
+        coVerify(exactly = 1) {
+            injectedOvp.authenticateVerifier(any<Map<String, Any>>())
         }
     }
 
@@ -122,8 +150,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
                     )
                 )
             },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
             openId4vp = mockOvp,
-            traceabilityId = "test-trace-id"
         )
 
         val result = handler.authorizeUser(validRequest())
@@ -146,8 +175,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { emptyMap() },
             signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
             openId4vp = mockOvp,
-            traceabilityId = "test-trace-id"
         )
 
         handler.authorizeUser(validRequest())
@@ -172,8 +202,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
             openId4vp = mockOvp,
-            traceabilityId = "test-trace-id"
         )
 
         assertThrows<InteractiveAuthorizationException> {
@@ -189,8 +220,9 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { validCredentialMap() },
             signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
             openId4vp = mockOvp,
-            traceabilityId = "test-trace-id"
         )
 
         assertThrows<InteractiveAuthorizationException> {

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -54,9 +54,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         // ✅ IMPORTANT: mock positionally (avoid overload + named args mismatch)
         coEvery {
             mockOvp.authenticateVerifier(
-                authorizationRequest = any(),
-                any(),
-                any(),
+                authorizationRequest = any<Map<String, Any>>(),
             )
         } returns fakeAuthRequest
 
@@ -73,11 +71,13 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
     private fun validCredentialMap() =
         mapOf(
-            "id1" to listOf(io.mosip.openID4VP.wallet.Credential(
-                format = FormatType.LDP_VC,
-                data = """{ "credentialSubject": { "id": "did:example:123" } }""",
-                credentialId = "c1"
-            ))
+            "id1" to listOf(
+                Credential(
+                    format = FormatType.LDP_VC,
+                    data = """{ "credentialSubject": { "id": "did:example:123" } }""",
+                    credentialId = "c1"
+                )
+            )
         )
 
     // ------------------------------------------------------------------------
@@ -87,6 +87,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         val handler = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation = { emptyMap() },
             signVerifiablePresentation = { emptyList() },
+            openId4vp = mockOvp,
             traceabilityId = "test-trace-id",
         )
 
@@ -132,9 +133,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         coVerify(exactly = 1) {
             mockOvp.authenticateVerifier(
-                authorizationRequest = any(),
-                any(),
-                any()
+                authorizationRequest = any<Map<String, Any>>(),
             )
         }
         coVerify(exactly = 1) { mockOvp.constructUnsignedVPToken(any()) }


### PR DESCRIPTION
#### Public API Changes

The `AuthorizationMethod` for `presentationDuringIssuance` has been updated to align with the changes in OVP library version 0.8.0. The following are the key changes in the public API:

##### 1. Removal of ldpVpSignatureSuite

- `ldpVpSignatureSuite` has been removed as part of the upgrade to OVP library version 0.8.0. This means that the `presentationDuringIssuance` authorization method will no longer support the Linked Data Proof (LDP) signature suite for verifiable presentations.
- This change is happening since OVP library version 0.8.0 has removed support for LDP signature suite input and uses `JsonWebSignatureSuite2020` as the default signature suite for verifiable presentations. Therefore, the `presentationDuringIssuance` authorization method will now only support the `JsonWebSignatureSuite2020` signature suite for `ldp_vp` verifiable presentations.

##### 2. SelectCredentialsForPresentationCallback callback Type
SelectCredentialsForPresentationCallback's type has now changed as per OVP library's changes. The following table summarizes the changes in the public API:

|        | 0.7.0                                    | New                         | Notes                                                                                                                                                                                                                                         |
|--------|------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Output | Map\<String, Map<FormatType, AnyCodable>> | Map\<String, Array<Credential>> | Previously, the selected credentials was required to be a map of input descriptor ID to selected credentials grouped by format. <br/> It now changes to map of input descriptor ID / credential Query ID to its list of selected `Credential` |

##### 3. SignVerifiablePresentationCallback callback Type
SignVerifiablePresentationCallback's type has now changed as per OVP library's changes. The following table summarizes the changes in the public API:

|        | 0.7.0                         | New                        | Notes                                                    |
|--------|-------------------------------|-------------------------------|----------------------------------------------------------|
| Input  | Array\<UnsignedVPTokenV2>      | Array\<UnsignedVPToken>        | This change is only name level and no structural changes |
| Output | Array\<VPTokenSigningResultV2> | Array\<VPTokenSigningResultV2> | This change is only name level and no structural changes |


Fixes: https://github.com/inji/inji-wallet/issues/24734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Updates**
  * Upgraded OpenID4VP library to 1.0.0-SNAPSHOT.

* **Improvements**
  * Migrated to the newer OpenID4VP token model and simplified presentation exchange flow.
  * Removed an optional signature-suite configuration and streamlined wallet configuration usage.
  * Simplified credential selection/signing interfaces to a consistent format.

* **Tests**
  * Updated unit tests to align with the new token model and added JVM Base64 support for tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->