### PR TITLE
fix(pdi): delegate authrequest validation to ovp library

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -107,7 +107,11 @@ class PresentationDuringIssuanceAuthorizationMethodService : AuthorizationMethod
 
 
     private fun validatePresentationRequest(request: Map<String, Any>): AuthorizationRequest {
-        return openId4vp.authenticateVerifier(request)
+        val authorizationRequest = openId4vp.authenticateVerifier(request)
+        if (authorizationRequest.responseMode !in listOf("iar-post", "iar-post.jwt")) {
+            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
+        }
+        return authorizationRequest
     }
 
     private suspend fun handlePresentation(vpRequest: AuthorizationRequest): Map<String, Any> {
@@ -172,5 +176,4 @@ class PresentationDuringIssuanceAuthorizationMethodService : AuthorizationMethod
             ?: throw InteractiveAuthorizationException("Issuer response deserialization failed")
     }
 }
-
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
@@ -23,30 +23,5 @@ data class PresentationInteractionResponse(
         if (openid4vpRequest.isEmpty()) {
             throw IllegalArgumentException("openid4vpRequest must not be empty")
         }
-
-        if (openid4vpRequest.containsKey("request")) {
-            validateSignedRequest()
-        } else {
-            validateUnsignedRequest()
-        }
     }
-
-    private fun validateUnsignedRequest() {
-        val responseType = openid4vpRequest["response_type"] as? String
-        if (responseType != "vp_token") {
-            throw IllegalArgumentException("response_type must be 'vp_token'")
-        }
-
-        val responseMode = openid4vpRequest["response_mode"] as? String
-            ?: throw IllegalArgumentException("Missing or invalid 'response_mode'")
-        if (responseMode !in listOf("iar-post", "iar-post.jwt")) {
-            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
-        }
-    }
-
-    private fun validateSignedRequest() {
-        openid4vpRequest["request"] as? String
-            ?: throw IllegalArgumentException("Missing or invalid 'request' JWT")
-    }
-
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -39,10 +39,10 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         fakeAuthRequest = AuthorizationPresentationExchangeRequest(
             clientId = "https://trusted.com",
             redirectUri = "",
-            responseType = "",
+            responseType = "vp_token",
             state = "",
             nonce = "",
-            responseMode = "",
+            responseMode = "iar-post",
             responseUri = null,
             walletNonce = "",
             clientMetadata = null,
@@ -125,6 +125,38 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
     }
 
     @Test
+    fun `should delegate request uri validation and accept iar post jwt mode`() = runTest {
+        val requestByReference = mapOf(
+            "request_uri" to "https://verifier.example.com/request/123"
+        )
+        val normalizedRequest = authorizationRequest(responseMode = "iar-post.jwt")
+        coEvery {
+            mockOvp.authenticateVerifier(requestByReference)
+        } returns normalizedRequest
+
+        var selectedRequest: AuthorizationRequest? = null
+        val handler = PresentationDuringIssuanceAuthorizationMethodService(
+            selectCredentialsForPresentation = {
+                selectedRequest = it
+                emptyMap()
+            },
+            signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
+            openId4vp = mockOvp,
+        )
+
+        handler.authorizeUser(
+            validRequest().copy(ovpRequest = requestByReference)
+        )
+
+        coVerify(exactly = 1) {
+            mockOvp.authenticateVerifier(requestByReference)
+        }
+        Assert.assertSame(normalizedRequest, selectedRequest)
+    }
+
+    @Test
     fun `should successfully authorize and return success response`() = runTest {
         coEvery { mockOvp.constructUnsignedVPToken(any()) } returns listOf(
             UnsignedVPToken(FormatType.LDP_VC, "k1","ES256", "unsigned".toByteArray())
@@ -187,6 +219,33 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
         coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any()) }
         coVerify(exactly = 0) { mockOvp.constructVPResponse(any()) }
     }
+
+    @Test
+    fun `should post error response when normalized response mode is unsupported`() = runTest {
+        coEvery {
+            mockOvp.authenticateVerifier(any<Map<String, Any>>())
+        } returns authorizationRequest(responseMode = "direct_post")
+
+        val handler = PresentationDuringIssuanceAuthorizationMethodService(
+            selectCredentialsForPresentation = {
+                Assert.fail("Credential selection must not run for an unsupported response mode")
+                emptyMap()
+            },
+            signVerifiablePresentation = { emptyList() },
+            openid4vpWalletConfig = WalletConfig(),
+            traceabilityId = "test-trace-id",
+            openId4vp = mockOvp,
+        )
+
+        handler.authorizeUser(validRequest())
+
+        verify(exactly = 1) {
+            mockOvp.constructErrorInfo(
+                match { it.message == "response_mode must be 'iar-post' or 'iar-post.jwt'" }
+            )
+        }
+        coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any()) }
+    }
     
     @Test
     fun `should throw when network post fails`() = runTest {
@@ -229,4 +288,23 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
             handler.authorizeUser(validRequest())
         }
     }
+
+    private fun authorizationRequest(
+        responseType: String = "vp_token",
+        responseMode: String? = "iar-post"
+    ) = AuthorizationPresentationExchangeRequest(
+        clientId = "https://trusted.com",
+        redirectUri = "",
+        responseType = responseType,
+        state = "",
+        nonce = "",
+        responseMode = responseMode,
+        responseUri = null,
+        walletNonce = "",
+        clientMetadata = null,
+        presentationDefinition = PresentationDefinition(
+            id = "pd-id",
+            inputDescriptors = emptyList()
+        )
+    )
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponseTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponseTest.kt
@@ -1,0 +1,61 @@
+package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance
+
+import io.mosip.vciclient.common.JsonUtils
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertNotNull
+
+class PresentationInteractionResponseTest {
+
+    @Test
+    fun `should accept request uri for library validation`() {
+        val response = validResponse(
+            openid4vpRequest = mapOf(
+                "request_uri" to "https://verifier.example.com/request/123"
+            )
+        )
+
+        assertDoesNotThrow {
+            response.validate()
+        }
+    }
+
+    @Test
+    fun `should leave signed request validation to OpenID4VP library`() {
+        val response = validResponse(
+            openid4vpRequest = mapOf("request" to "signed-request-jwt")
+        )
+
+        assertDoesNotThrow {
+            response.validate()
+        }
+    }
+
+    @Test
+    fun `should reject empty OpenID4VP request`() {
+        val response = validResponse(openid4vpRequest = emptyMap())
+
+        assertThrows<IllegalArgumentException> {
+            response.validate()
+        }
+    }
+
+    private fun validResponse(openid4vpRequest: Map<String, Any>): PresentationInteractionResponse {
+        val responseJson = JsonUtils.serialize(
+            mapOf(
+                "status" to "require_interaction",
+                "type" to "openid4vp_presentation",
+                "auth_session" to "auth-session",
+                "openid4vp_request" to openid4vpRequest
+            )
+        )
+
+        return assertNotNull(
+            JsonUtils.deserialize(
+                responseJson,
+                PresentationInteractionResponse::class.java
+            )
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of presentation request authentication modes during credential issuance, with stricter checks for supported response modes.
  * Simplified validation logic for presentation requests to focus on core requirements.

* **Tests**
  * Expanded test coverage for authentication mode validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->