### PR TITLE
fix(v1) path component before credential issuer wellknwon suffix

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
@@ -9,6 +9,7 @@ import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.net.URI
 
 private const val CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX = "/.well-known/openid-credential-issuer"
 
@@ -87,9 +88,29 @@ class IssuerMetadataService {
         return configurations as Map<String, Any>
     }
 
-    suspend fun fetchAndParseIssuerMetadata(credentialIssuer: String): Map<String, Any> = withContext(Dispatchers.IO) {
-        val wellKnownUrl = "$credentialIssuer$CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX"
+    suspend fun fetchAndParseIssuerMetadata(credentialIssuer: String): Map<String, Any> =
+        withContext(Dispatchers.IO) {
+            val wellKnownUrl: String
+            val draft13WellKnownUrl: String
+            try {
+                wellKnownUrl = buildWellKnownUrl(credentialIssuer)
+                draft13WellKnownUrl = buildDraft13WellKnownUrl(credentialIssuer)
+            } catch (e: Exception) {
+                throw IssuerMetadataFetchException(
+                    "Invalid credential issuer URL: $credentialIssuer",
+                    cause = e
+                )
+            }
 
+            try {
+                fetchAndParse(wellKnownUrl)
+            } catch (error: IssuerMetadataFetchException) {
+                if (draft13WellKnownUrl == wellKnownUrl) throw error
+                fetchAndParse(draft13WellKnownUrl)
+            }
+        }
+
+    private fun fetchAndParse(wellKnownUrl: String): Map<String, Any> {
         try {
             val response = NetworkManager.sendRequest(
                 url = wellKnownUrl,
@@ -101,8 +122,7 @@ class IssuerMetadataService {
             if (body.isBlank()) {
                 throw IssuerMetadataFetchException("Issuer metadata response is empty.")
             }
-
-            return@withContext JsonUtils.toMap(body)
+            return JsonUtils.toMap(body)
         } catch (e: IssuerMetadataFetchException) {
             throw e
         } catch (e: VCIClientException) {
@@ -118,6 +138,17 @@ class IssuerMetadataService {
                 cause = e
             )
         }
+    }
+
+    private fun buildWellKnownUrl(credentialIssuer: String): String {
+        val uri = URI(credentialIssuer)
+        val path = uri.path?.trimEnd('/').orEmpty()
+        return "${uri.scheme}://${uri.authority}$CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX$path"
+    }
+
+    private fun buildDraft13WellKnownUrl(credentialIssuer: String): String {
+        val normalizedIssuer = credentialIssuer.trimEnd('/')
+        return "$normalizedIssuer$CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX"
     }
 
     private fun validateCredentialIssuerMatch(

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataServiceTest.kt
@@ -60,6 +60,34 @@ class IssuerMetadataServiceTest {
     }
 
     @Test
+    fun `uses OID4VCI 1_0 insert-style well-known URL for a path-bearing issuer`() = runBlocking {
+        val pathIssuer = "https://mock.issuer/tenant1"
+        val v1Url = "https://mock.issuer/.well-known/openid-credential-issuer/tenant1"
+        val draft13Url = "https://mock.issuer/tenant1/.well-known/openid-credential-issuer"
+        every { NetworkManager.sendRequest(v1Url, any(), any()) } returns NetworkResponse(wellKnownResponse, null)
+
+        IssuerMetadataService().fetchAndParseIssuerMetadata(pathIssuer)
+
+        verify(exactly = 1) { NetworkManager.sendRequest(v1Url, any(), any()) }
+        verify(exactly = 0) { NetworkManager.sendRequest(draft13Url, any(), any()) }
+    }
+
+    @Test
+    fun `falls back to Draft 13 append-style well-known URL when the 1_0 location fails`() = runBlocking {
+        val pathIssuer = "https://mock.issuer/tenant1"
+        val v1Url = "https://mock.issuer/.well-known/openid-credential-issuer/tenant1"
+        val draft13Url = "https://mock.issuer/tenant1/.well-known/openid-credential-issuer"
+        every { NetworkManager.sendRequest(v1Url, any(), any()) } throws Exception("not found")
+        every { NetworkManager.sendRequest(draft13Url, any(), any()) } returns NetworkResponse(wellKnownResponse, null)
+
+        val result = IssuerMetadataService().fetchAndParseIssuerMetadata(pathIssuer)
+
+        assertEquals(wellKnownResponseMap, result)
+        verify(exactly = 1) { NetworkManager.sendRequest(v1Url, any(), any()) }
+        verify(exactly = 1) { NetworkManager.sendRequest(draft13Url, any(), any()) }
+    }
+
+    @Test
     fun `should parse ldp_vc metadata successfully`() = runBlocking {
         mockJsonResponse(LDP_VC_JSON)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced issuer metadata discovery with automatic fallback mechanism, enabling the service to intelligently retry using alternative URL formats when the primary endpoint becomes unavailable, thereby improving cross-issuer compatibility and resilience

* **Tests**
  * Added comprehensive unit tests to verify correct issuer metadata URL construction and validate fallback retry behavior during metadata discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->