### PR TITLE
feat(vci-client):Add Pushed Authorizarion Request changes

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
@@ -145,6 +145,8 @@ internal class AuthorizationCodeFlowService(
         try {
             val pkceSession = pkceSessionManager.createSession()
 
+            val issuerState = credentialOffer?.grants?.authorizationCodeGrant?.issuerState
+
             val authorizationServerMetadata = try {
                 authorizationServerResolver.resolveForAuthCode(issuerMetadata, credentialOffer)
             } catch (e: DownloadFailedException) {
@@ -172,6 +174,7 @@ internal class AuthorizationCodeFlowService(
                     getTokenResponse = getTokenResponse,
                     credentialConfigurationId = credentialConfigurationId,
                     authorizationMethods = authorizationMethods,
+                    issuerState = issuerState,
                     traceabilityId = traceabilityId
                 )
             } catch (e: DownloadFailedException) {
@@ -216,6 +219,7 @@ internal class AuthorizationCodeFlowService(
         getTokenResponse: TokenResponseCallback,
         credentialConfigurationId: String,
         authorizationMethods: List<AuthorizationMethod>,
+        issuerState: String? = null,
         traceabilityId: String? = null,
     ): TokenResponse {
         val tokenEndpoint = issuerMetadata.tokenEndpoint
@@ -231,6 +235,7 @@ internal class AuthorizationCodeFlowService(
             pkceSession = pkceSession,
             credentialConfigurationId = credentialConfigurationId,
             authorizationMethods = authorizationMethods,
+            issuerState = issuerState,
             traceabilityId = traceabilityId
         )
 
@@ -273,6 +278,7 @@ internal class AuthorizationCodeFlowService(
         pkceSession: PKCESessionManager.PKCESession,
         credentialConfigurationId: String,
         authorizationMethods: List<AuthorizationMethod>,
+        issuerState: String? = null,
         traceabilityId: String? = null,
     ): String {
         val interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint
@@ -296,7 +302,8 @@ internal class AuthorizationCodeFlowService(
                         issuerMetadata = issuerMetadata,
                         clientMetadata = clientMetadata,
                         pkceSession = pkceSession,
-                        authorizationMethods = authorizationMethods
+                        authorizationMethods = authorizationMethods,
+                        issuerState = issuerState
                     )
                 } else {
                     throw e
@@ -308,7 +315,8 @@ internal class AuthorizationCodeFlowService(
                 issuerMetadata = issuerMetadata,
                 clientMetadata = clientMetadata,
                 pkceSession = pkceSession,
-                authorizationMethods = authorizationMethods
+                authorizationMethods = authorizationMethods,
+                issuerState = issuerState
             )
         }
     }
@@ -363,6 +371,7 @@ internal class AuthorizationCodeFlowService(
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
         authorizationMethods: List<AuthorizationMethod>,
+        issuerState: String? = null,
     ): String {
         val authorizationEndpoint = authorizationServerMetadata.authorizationEndpoint
             ?: throw DownloadFailedException(
@@ -383,7 +392,10 @@ internal class AuthorizationCodeFlowService(
                 authorizeUrl = authorizationEndpoint,
                 clientMetadata = clientMetadata,
                 pkceSession = pkceSession,
-                scope = issuerMetadata.scope
+                scope = issuerMetadata.scope,
+                pushedAuthorizationRequestEndpoint =
+                    authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
+                issuerState = issuerState
             )
 
             val response = try {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/implicitAuthorization/ImplicitAuthorizationRequestData.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/implicitAuthorization/ImplicitAuthorizationRequestData.kt
@@ -9,4 +9,7 @@ data class ImplicitAuthorizationRequestData(
     val clientMetadata: ClientMetadata,
     val pkceSession: PKCESessionManager.PKCESession,
     val scope: String,
+    val pushedAuthorizationRequestEndpoint: String? = null,
+    val authorizationDetails: String? = null,
+    val issuerState: String? = null,
 ) : AuthorizationRequestData()

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/redirectToWeb/RedirectToWebAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/redirectToWeb/RedirectToWebAuthorizationMethodService.kt
@@ -6,11 +6,13 @@ import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.request
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.response.AuthorizationResponse
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.InteractionType
 import io.mosip.vciclient.authorizationServer.AuthorizationUrlBuilder
+import io.mosip.vciclient.authorizationServer.PushedAuthorizationRequestService
 import io.mosip.vciclient.constants.OpenWebPageCallback
 import io.mosip.vciclient.exception.InteractiveAuthorizationException
 
 class RedirectToWebAuthorizationMethodService(
-    val openWebPage: OpenWebPageCallback
+    val openWebPage: OpenWebPageCallback,
+    private val parService: PushedAuthorizationRequestService = PushedAuthorizationRequestService(),
 ) : AuthorizationMethodService {
 
     override fun type(): String {
@@ -25,15 +27,35 @@ class RedirectToWebAuthorizationMethodService(
             )
         }
 
-        val authUrl = AuthorizationUrlBuilder.build(
-            baseUrl = requestData.authorizeUrl,
-            clientId = requestData.clientMetadata.clientId,
-            redirectUri = requestData.clientMetadata.redirectUri,
-            scope = requestData.scope,
-            state = requestData.pkceSession.state,
-            codeChallenge = requestData.pkceSession.codeChallenge,
-            nonce = requestData.pkceSession.nonce
-        )
+        val parEndpoint = requestData.pushedAuthorizationRequestEndpoint
+        val authUrl = if (!parEndpoint.isNullOrBlank()) {
+            val parResponse = parService.pushAuthorizationRequest(
+                parEndpoint = parEndpoint,
+                clientId = requestData.clientMetadata.clientId,
+                redirectUri = requestData.clientMetadata.redirectUri,
+                codeChallenge = requestData.pkceSession.codeChallenge,
+                state = requestData.pkceSession.state,
+                nonce = requestData.pkceSession.nonce,
+                scope = requestData.scope,
+                authorizationDetails = requestData.authorizationDetails,
+                issuerState = requestData.issuerState
+            )
+            AuthorizationUrlBuilder.buildWithRequestUri(
+                baseUrl = requestData.authorizeUrl,
+                clientId = requestData.clientMetadata.clientId,
+                requestUri = parResponse.requestUri
+            )
+        } else {
+            AuthorizationUrlBuilder.build(
+                baseUrl = requestData.authorizeUrl,
+                clientId = requestData.clientMetadata.clientId,
+                redirectUri = requestData.clientMetadata.redirectUri,
+                scope = requestData.scope,
+                state = requestData.pkceSession.state,
+                codeChallenge = requestData.pkceSession.codeChallenge,
+                nonce = requestData.pkceSession.nonce
+            )
+        }
         val authorizationResponse = openWebPage(authUrl)
 
         if (authorizationResponse.containsKey("error")) {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerMetadata.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerMetadata.kt
@@ -16,5 +16,11 @@ data class AuthorizationServerMetadata(
     val authorizationEndpoint: String? = null,
 
     @SerializedName("interactive_authorization_endpoint")
-    val interactiveAuthorizationEndpoint: String? = null
+    val interactiveAuthorizationEndpoint: String? = null,
+
+    @SerializedName("pushed_authorization_request_endpoint")
+    val pushedAuthorizationRequestEndpoint: String? = null,
+
+    @SerializedName("require_pushed_authorization_requests")
+    val requirePushedAuthorizationRequests: Boolean? = null
 )

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationUrlBuilder.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationUrlBuilder.kt
@@ -29,6 +29,18 @@ object AuthorizationUrlBuilder {
         }
     }
 
+    fun buildWithRequestUri(
+        baseUrl: String,
+        clientId: String,
+        requestUri: String,
+    ): String {
+        return buildString {
+            append(baseUrl)
+            append("?client_id=").append(encode(clientId))
+            append("&request_uri=").append(encode(requestUri))
+        }
+    }
+
     private fun encode(value: String): String =
         URLEncoder.encode(value, "UTF-8")
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationRequestService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationRequestService.kt
@@ -1,0 +1,88 @@
+package io.mosip.vciclient.authorizationServer
+
+import io.mosip.vciclient.common.JsonUtils
+import io.mosip.vciclient.constants.AuthorizationResponseType
+import io.mosip.vciclient.constants.CodeChallengeMethod
+import io.mosip.vciclient.constants.Constants
+import io.mosip.vciclient.constants.Constants.APPLICATION_X_WWW_FORM_URLENCODED
+import io.mosip.vciclient.constants.Constants.CONTENT_TYPE
+import io.mosip.vciclient.exception.PushedAuthorizationRequestException
+import io.mosip.vciclient.exception.VCIClientException
+import io.mosip.vciclient.networkManager.HttpMethod
+import io.mosip.vciclient.networkManager.NetworkManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.logging.Logger
+
+class PushedAuthorizationRequestService {
+    private val logger = Logger.getLogger(javaClass.simpleName)
+
+    suspend fun pushAuthorizationRequest(
+        parEndpoint: String,
+        clientId: String,
+        redirectUri: String,
+        codeChallenge: String,
+        state: String,
+        nonce: String,
+        scope: String? = null,
+        authorizationDetails: String? = null,
+        issuerState: String? = null,
+        codeChallengeMethod: CodeChallengeMethod = CodeChallengeMethod.S256,
+        responseType: AuthorizationResponseType = AuthorizationResponseType.CODE,
+        clientAuthParams: Map<String, String> = emptyMap(),
+        timeoutMillis: Long = Constants.DEFAULT_NETWORK_TIMEOUT_IN_MILLIS,
+    ): PushedAuthorizationResponse = withContext(Dispatchers.IO) {
+        val params = mutableMapOf(
+            "response_type" to responseType.value,
+            "client_id" to clientId,
+            "redirect_uri" to redirectUri,
+            "code_challenge" to codeChallenge,
+            "code_challenge_method" to codeChallengeMethod.value,
+            "state" to state,
+            "nonce" to nonce,
+        )
+        if (!authorizationDetails.isNullOrBlank()) {
+            params["authorization_details"] = authorizationDetails
+        } else if (!scope.isNullOrBlank()) {
+            params["scope"] = scope
+        }
+        if (!issuerState.isNullOrBlank()) params["issuer_state"] = issuerState
+        params.putAll(clientAuthParams)
+
+        logger.info("Pushing authorization request to PAR endpoint: $parEndpoint")
+
+        val response = try {
+            NetworkManager.sendRequest(
+                url = parEndpoint,
+                method = HttpMethod.POST,
+                headers = mapOf(CONTENT_TYPE to APPLICATION_X_WWW_FORM_URLENCODED),
+                bodyParams = params,
+                timeoutMillis = timeoutMillis,
+            )
+        } catch (e: VCIClientException) {
+            throw PushedAuthorizationRequestException(
+                "PAR request failed at $parEndpoint: ${e.message}",
+                serverErrorCode = e.serverErrorCode,
+                serverErrorDescription = e.serverErrorDescription,
+                cause = e,
+            )
+        } catch (e: Exception) {
+            throw PushedAuthorizationRequestException(
+                "PAR request failed at $parEndpoint: ${e.message}",
+                serverErrorCode = null,
+                serverErrorDescription = null,
+                cause = e,
+            )
+        }
+
+        val parResponse = JsonUtils.deserialize(
+            response.body, PushedAuthorizationResponse::class.java
+        )
+        if (parResponse == null || parResponse.requestUri.isBlank()) {
+            throw PushedAuthorizationRequestException(
+                "Invalid PAR response from $parEndpoint: missing request_uri"
+            )
+        }
+        parResponse
+    }
+}

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationResponse.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationResponse.kt
@@ -1,0 +1,11 @@
+package io.mosip.vciclient.authorizationServer
+
+import com.google.gson.annotations.SerializedName
+
+data class PushedAuthorizationResponse(
+    @SerializedName("request_uri")
+    val requestUri: String,
+
+    @SerializedName("expires_in")
+    val expiresIn: Long? = null,
+)

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/PushedAuthorizationRequestException.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/PushedAuthorizationRequestException.kt
@@ -1,0 +1,22 @@
+package io.mosip.vciclient.exception
+
+class PushedAuthorizationRequestException : VCIClientException {
+
+    constructor(message: String?) : super(
+        code = "VCI-PAR",
+        message = "Pushed authorization request failed : $message"
+    )
+
+    constructor(
+        message: String?,
+        serverErrorCode: String?,
+        serverErrorDescription: String?,
+        cause: Throwable? = null
+    ) : super(
+        code = "VCI-PAR",
+        message = "Pushed authorization request failed : $message",
+        serverErrorCode = serverErrorCode,
+        serverErrorDescription = serverErrorDescription,
+        cause = cause
+    )
+}

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowServiceTest.kt
@@ -70,6 +70,9 @@ class AuthorizationCodeFlowServiceTest {
         mockkConstructor(JWTProof::class)
 
         every { anyConstructed<PKCESessionManager>().createSession() } returns pkceSession
+
+        every { credentialOffer.grants } returns null
+
         every {
             anyConstructed<CredentialRequestExecutor>().requestCredentialDraft13(
                 any(),
@@ -89,6 +92,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns null
+            every { pushedAuthorizationRequestEndpoint } returns null
         }
 
         every {
@@ -420,6 +424,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+            every { pushedAuthorizationRequestEndpoint } returns null
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/redirectToWeb/RedirectToWebAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/redirectToWeb/RedirectToWebAuthorizationMethodServiceTest.kt
@@ -1,6 +1,7 @@
 package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.redirectToWeb
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -8,6 +9,8 @@ import io.mosip.vciclient.authorizationCodeFlow.implicitAuthorization.ImplicitAu
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.InteractionType
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.request.AuthorizationRequestData
 import io.mosip.vciclient.authorizationServer.AuthorizationUrlBuilder
+import io.mosip.vciclient.authorizationServer.PushedAuthorizationRequestService
+import io.mosip.vciclient.authorizationServer.PushedAuthorizationResponse
 import io.mosip.vciclient.constants.OpenWebPageCallback
 import io.mosip.vciclient.exception.InteractiveAuthorizationException
 import io.mosip.vciclient.pkce.PKCESessionManager
@@ -130,6 +133,105 @@ class RedirectToWebAuthorizationMethodServiceTest {
         )
     }
 
+
+    @Test
+    fun `should push authorization request and use short URL when PAR endpoint present`() = runTest {
+        every {
+            AuthorizationUrlBuilder.buildWithRequestUri(any(), any(), any())
+        } returns "https://auth.example.com/authorize?client_id=client-id&request_uri=urn:req:abc"
+
+        val parService = mockk<PushedAuthorizationRequestService>()
+        coEvery {
+            parService.pushAuthorizationRequest(
+                parEndpoint = any(),
+                clientId = any(),
+                redirectUri = any(),
+                codeChallenge = any(),
+                state = any(),
+                nonce = any(),
+                scope = any(),
+                authorizationDetails = any(),
+                issuerState = any()
+            )
+        } returns PushedAuthorizationResponse("urn:req:abc", 90)
+
+        coEvery { openWebPage.invoke(any()) } returns mapOf("code" to "auth-code-123")
+
+        val service = RedirectToWebAuthorizationMethodService(openWebPage, parService)
+        val response = service.authorizeUser(parRequest())
+
+        assertEquals("success", response.status)
+        assertEquals("auth-code-123", response.authorizationCode)
+
+        coVerify(exactly = 1) {
+            parService.pushAuthorizationRequest(
+                parEndpoint = "https://as.example.com/as/par",
+                clientId = "client-id",
+                redirectUri = "app://callback",
+                codeChallenge = "challenge",
+                state = "state",
+                nonce = "nonce",
+                scope = "openid",
+                authorizationDetails = null,
+                issuerState = "issuer-state-xyz"
+            )
+        }
+        io.mockk.verify(exactly = 1) {
+            AuthorizationUrlBuilder.buildWithRequestUri(
+                "https://auth.example.com", "client-id", "urn:req:abc"
+            )
+        }
+    }
+
+    @Test
+    fun `should use long URL and not call PAR when PAR endpoint absent`() = runTest {
+        val parService = mockk<PushedAuthorizationRequestService>()
+        coEvery { openWebPage.invoke(any()) } returns mapOf("code" to "auth-code-123")
+
+        val service = RedirectToWebAuthorizationMethodService(openWebPage, parService)
+        val response = service.authorizeUser(standardRequest())
+
+        assertEquals("success", response.status)
+        assertEquals("auth-code-123", response.authorizationCode)
+
+        coVerify(exactly = 0) {
+            parService.pushAuthorizationRequest(
+                parEndpoint = any(),
+                clientId = any(),
+                redirectUri = any(),
+                codeChallenge = any(),
+                state = any(),
+                nonce = any(),
+                scope = any(),
+                authorizationDetails = any(),
+                issuerState = any()
+            )
+        }
+        io.mockk.verify(exactly = 1) {
+            AuthorizationUrlBuilder.build(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        }
+    }
+
+    private fun parRequest(): ImplicitAuthorizationRequestData {
+        return ImplicitAuthorizationRequestData(
+            authorizeUrl = "https://auth.example.com",
+            clientMetadata = ClientMetadata(
+                clientId = "client-id",
+                redirectUri = "app://callback"
+            ),
+            pkceSession = PKCESessionManager.PKCESession(
+                codeVerifier = "verifier",
+                codeChallenge = "challenge",
+                state = "state",
+                nonce = "nonce"
+            ),
+            scope = "openid",
+            pushedAuthorizationRequestEndpoint = "https://as.example.com/as/par",
+            issuerState = "issuer-state-xyz"
+        )
+    }
 
     private fun standardRequest(): ImplicitAuthorizationRequestData {
         return ImplicitAuthorizationRequestData(

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationUrlBuilderTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationUrlBuilderTest.kt
@@ -29,4 +29,19 @@ class AuthorizationUrlBuilderTest {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `buildWithRequestUri should return short URL with client_id and request_uri`() {
+        val actual = AuthorizationUrlBuilder.buildWithRequestUri(
+            baseUrl = "https://example.com/auth",
+            clientId = "myClientId",
+            requestUri = "urn:ietf:params:oauth:request_uri:abc123"
+        )
+
+        val expected = "https://example.com/auth" +
+                "?client_id=myClientId" +
+                "&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Aabc123"
+
+        assertEquals(expected, actual)
+    }
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationRequestServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/PushedAuthorizationRequestServiceTest.kt
@@ -1,0 +1,247 @@
+package io.mosip.vciclient.authorizationServer
+
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mosip.vciclient.common.JsonUtils
+import io.mosip.vciclient.exception.NetworkRequestFailedException
+import io.mosip.vciclient.exception.PushedAuthorizationRequestException
+import io.mosip.vciclient.networkManager.HttpMethod
+import io.mosip.vciclient.networkManager.NetworkManager
+import io.mosip.vciclient.networkManager.NetworkResponse
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+
+class PushedAuthorizationRequestServiceTest {
+
+    private val parEndpoint = "https://as.example.com/as/par"
+    private val responseBody = """{"request_uri":"urn:ietf:params:oauth:request_uri:abc","expires_in":90}"""
+
+    @Before
+    fun setUp() {
+        mockkObject(NetworkManager)
+        mockkObject(JsonUtils)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun stubSuccessNetwork(bodySlot: CapturingSlot<Map<String, String>>) {
+        every {
+            NetworkManager.sendRequest(parEndpoint, HttpMethod.POST, any(), capture(bodySlot), any())
+        } returns NetworkResponse(responseBody, null)
+    }
+
+    private fun stubDeserialize(response: PushedAuthorizationResponse?) {
+        every {
+            JsonUtils.deserialize(any(), PushedAuthorizationResponse::class.java)
+        } returns response
+    }
+
+    @Test
+    fun `should return request_uri and expires_in on success`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:ietf:params:oauth:request_uri:abc", 90))
+
+        val result = PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid"
+        )
+
+        assertEquals("urn:ietf:params:oauth:request_uri:abc", result.requestUri)
+        assertEquals(90L, result.expiresIn)
+    }
+
+    @Test
+    fun `should always include core params including nonce`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:request_uri:abc"))
+
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid"
+        )
+
+        val body = bodySlot.captured
+        assertEquals("code", body["response_type"])
+        assertEquals("client-id", body["client_id"])
+        assertEquals("app://callback", body["redirect_uri"])
+        assertEquals("challenge", body["code_challenge"])
+        assertEquals("S256", body["code_challenge_method"])
+        assertEquals("state-123", body["state"])
+        assertEquals("nonce-123", body["nonce"])
+    }
+
+    @Test
+    fun `should send authorization_details when provided and omit scope`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:request_uri:abc"))
+
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid",
+            authorizationDetails = """[{"type":"openid_credential"}]"""
+        )
+
+        val body = bodySlot.captured
+        assertEquals("""[{"type":"openid_credential"}]""", body["authorization_details"])
+        assertFalse(body.containsKey("scope"))
+    }
+
+    @Test
+    fun `should send scope when authorization_details is absent`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:request_uri:abc"))
+
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid"
+        )
+
+        val body = bodySlot.captured
+        assertEquals("openid", body["scope"])
+        assertFalse(body.containsKey("authorization_details"))
+    }
+
+    @Test
+    fun `should include issuer_state only when present`() = runBlocking {
+        val withSlot = slot<Map<String, String>>()
+        stubSuccessNetwork(withSlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:request_uri:abc"))
+
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid",
+            issuerState = "issuer-state-xyz"
+        )
+        assertEquals("issuer-state-xyz", withSlot.captured["issuer_state"])
+
+        val withoutSlot = slot<Map<String, String>>()
+        stubSuccessNetwork(withoutSlot)
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid"
+        )
+        assertFalse(withoutSlot.captured.containsKey("issuer_state"))
+    }
+
+    @Test
+    fun `should merge clientAuthParams into the body`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(PushedAuthorizationResponse("urn:request_uri:abc"))
+
+        PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint = parEndpoint,
+            clientId = "client-id",
+            redirectUri = "app://callback",
+            codeChallenge = "challenge",
+            state = "state-123",
+            nonce = "nonce-123",
+            scope = "openid",
+            clientAuthParams = mapOf(
+                "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion" to "signed.jwt.value"
+            )
+        )
+
+        val body = bodySlot.captured
+        assertEquals(
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            body["client_assertion_type"]
+        )
+        assertEquals("signed.jwt.value", body["client_assertion"])
+    }
+
+    @Test
+    fun `should throw when response has no request_uri`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        stubSuccessNetwork(bodySlot)
+        stubDeserialize(null)
+
+        val ex = assertThrows<PushedAuthorizationRequestException> {
+            PushedAuthorizationRequestService().pushAuthorizationRequest(
+                parEndpoint = parEndpoint,
+                clientId = "client-id",
+                redirectUri = "app://callback",
+                codeChallenge = "challenge",
+                state = "state-123",
+                nonce = "nonce-123",
+                scope = "openid"
+            )
+        }
+        assertTrue(ex.message.contains("missing request_uri"))
+    }
+
+    @Test
+    fun `should wrap server error and propagate serverErrorCode`() = runBlocking {
+        val bodySlot = slot<Map<String, String>>()
+        every {
+            NetworkManager.sendRequest(parEndpoint, HttpMethod.POST, any(), capture(bodySlot), any())
+        } throws NetworkRequestFailedException(
+            "HTTP 401",
+            "invalid_client",
+            "Client authentication failed",
+            null
+        )
+
+        val ex = assertThrows<PushedAuthorizationRequestException> {
+            PushedAuthorizationRequestService().pushAuthorizationRequest(
+                parEndpoint = parEndpoint,
+                clientId = "client-id",
+                redirectUri = "app://callback",
+                codeChallenge = "challenge",
+                state = "state-123",
+                nonce = "nonce-123",
+                scope = "openid"
+            )
+        }
+        assertEquals("invalid_client", ex.serverErrorCode)
+        assertEquals("Client authentication failed", ex.serverErrorDescription)
+    }
+}


### PR DESCRIPTION
## Added support for Pushed Authorization Requests (PAR) in the Authorization Code Flow.

## Changes
Discovered PAR endpoint from Authorization Server metadata.
Pushed authorization request parameters to the PAR endpoint before authorization.
Used returned request_uri for Authorization Endpoint redirection.
Added error handling for PAR failures and invalid responses.
Added test coverage for:
Successful PAR flow
Missing PAR endpoint
Invalid PAR response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Pushed Authorization Request (PAR) flow in authorization code grant
  * Issuer state is now extracted from credential offers and passed through authorization flow
  * Authorization server metadata now includes PAR endpoint configuration

* **Tests**
  * Added comprehensive test coverage for PAR functionality
  * Added tests for authorization URL generation with PAR request URIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->