### PR TITLE
Add DCP IAE support

### DIFF
--- a/kotlin/vci-client/build.gradle.kts
+++ b/kotlin/vci-client/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     testImplementation("org.json:json:20231013")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     implementation("com.squareup.okio:okio:3.6.0")
-    implementation("io.inji:inji-openid4vp-aar:1.0.0-SNAPSHOT")
+    implementation("io.inji:inji-openid4vp-aar:1.0.0-alpha.2-SNAPSHOT")
     testImplementation(kotlin("test"))
 }
 

--- a/kotlin/vci-client/publish-artifact.gradle
+++ b/kotlin/vci-client/publish-artifact.gradle
@@ -98,7 +98,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "inji-vci-client-aar"
-            version = "1.0.0-SNAPSHOT"
+            version = "1.0.0-alpha.2-SNAPSHOT"
             archivesBaseName = "${artifactId}-${version}"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt
@@ -267,65 +267,77 @@ internal class AuthorizationCodeFlowService(
     }
 
     private suspend fun obtainAuthorizationCode(
-        authorizationServerMetadata: AuthorizationServerMetadata,
-        issuerMetadata: IssuerMetadata,
-        clientMetadata: ClientMetadata,
-        pkceSession: PKCESessionManager.PKCESession,
-        credentialConfigurationId: String,
-        authorizationMethods: List<AuthorizationMethod>,
-        traceabilityId: String? = null,
-    ): String {
-        val interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint
+    authorizationServerMetadata: AuthorizationServerMetadata,
+    issuerMetadata: IssuerMetadata,
+    clientMetadata: ClientMetadata,
+    pkceSession: PKCESessionManager.PKCESession,
+    credentialConfigurationId: String,
+    authorizationMethods: List<AuthorizationMethod>,
+    traceabilityId: String? = null,
+): String {
 
-        return if (interactiveEndpoint != null) {
-            try {
-                obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
-                    endpoint = interactiveEndpoint,
-                    issuerMetadata = issuerMetadata,
-                    clientMetadata = clientMetadata,
-                    pkceSession = pkceSession,
-                    credentialConfigurationId = credentialConfigurationId,
-                    authorizationMethods = authorizationMethods,
-                    traceabilityId = traceabilityId
-                )
-            } catch (e: DownloadFailedException) {
-                if (e.issuerErrorCode == MISSING_INTERACTION_TYPE_ERROR) {
-                    logger.warning("Interactive authorization failed at $interactiveEndpoint: ${e.message}. Falling back to standard authorization endpoint if available.")
-                    obtainAuthorizationCodeViaAuthorizationEndpoint(
-                        authorizationServerMetadata = authorizationServerMetadata,
-                        issuerMetadata = issuerMetadata,
-                        clientMetadata = clientMetadata,
-                        pkceSession = pkceSession,
-                        authorizationMethods = authorizationMethods
-                    )
-                } else {
-                    throw e
-                }
-            }
-        } else {
-            obtainAuthorizationCodeViaAuthorizationEndpoint(
-                authorizationServerMetadata = authorizationServerMetadata,
+    val interactiveEndpoint =
+        authorizationServerMetadata.interactiveAuthorizationEndpoint?.trim()
+
+    val hasInteractiveEndpoint = !interactiveEndpoint.isNullOrEmpty()
+
+    if (
+        authorizationServerMetadata.requireInteractiveAuthorizationRequest == true &&
+        !hasInteractiveEndpoint
+    ) {
+        throw DownloadFailedException("Missing interactive authorization endpoint")
+    }
+
+    return if (hasInteractiveEndpoint) {
+        try {
+              obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
+                endpoint = interactiveEndpoint!!,
                 issuerMetadata = issuerMetadata,
                 clientMetadata = clientMetadata,
                 pkceSession = pkceSession,
-                authorizationMethods = authorizationMethods
+                credentialConfigurationId = credentialConfigurationId,
+                authorizationMethods = authorizationMethods,
+                traceabilityId = traceabilityId
             )
+        } catch (e: DownloadFailedException) {
+            if (
+                e.issuerErrorCode == MISSING_INTERACTION_TYPE_ERROR &&
+                authorizationServerMetadata.requireInteractiveAuthorizationRequest != true
+            ) {
+                logger.warning(
+                    "Interactive authorization failed at $interactiveEndpoint: ${e.message}. Falling back to standard authorization endpoint if available."
+                )
+
+                obtainAuthorizationCodeViaAuthorizationEndpoint(
+                    authorizationServerMetadata = authorizationServerMetadata,
+                    issuerMetadata = issuerMetadata,
+                    clientMetadata = clientMetadata,
+                    pkceSession = pkceSession,
+                    authorizationMethods = authorizationMethods
+                )
+            } else {
+                throw e
+            }
         }
-    }
-
-    private suspend fun obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
-        endpoint: String,
-        issuerMetadata: IssuerMetadata,
-        clientMetadata: ClientMetadata,
-        pkceSession: PKCESessionManager.PKCESession,
-        credentialConfigurationId: String,
-        authorizationMethods: List<AuthorizationMethod>,
-        traceabilityId: String? = null,
-    ): String {
-        logger.info(
-            "Using Interactive Authorization Endpoint: $endpoint for issuer=${issuerMetadata.credentialIssuer}"
+    } else {
+        obtainAuthorizationCodeViaAuthorizationEndpoint(
+            authorizationServerMetadata = authorizationServerMetadata,
+            issuerMetadata = issuerMetadata,
+            clientMetadata = clientMetadata,
+            pkceSession = pkceSession,
+            authorizationMethods = authorizationMethods
         )
-
+    }
+}
+private suspend fun obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
+    endpoint: String,
+    issuerMetadata: IssuerMetadata,
+    clientMetadata: ClientMetadata,
+    pkceSession: PKCESessionManager.PKCESession,
+    credentialConfigurationId: String,
+    authorizationMethods: List<AuthorizationMethod>,
+    traceabilityId: String? = null,
+): String {
         val response = try {
             interactiveAuthorizationHandler.handle(
                 endpoint = endpoint,

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt
@@ -16,5 +16,5 @@ sealed class AuthorizationMethod(val type: InteractionType) {
         val openid4vpWalletConfig: WalletConfig = WalletConfig(),
         val selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
         val signVerifiablePresentation: SignVerifiablePresentationCallback
-    ) : AuthorizationMethod(type = InteractionType.OpenId4VpPresentation)
+    ) : AuthorizationMethod(type = InteractionType.OpenId4VpPresentationIAE)
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractionType.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractionType.kt
@@ -2,5 +2,6 @@ package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handle
 
 enum class InteractionType(val value: String) {
     RedirectToWeb("redirect_to_web"),
-    OpenId4VpPresentation("openid4vp_presentation")
+    OpenId4VpPresentation("openid4vp_presentation"),
+    OpenId4VpPresentationIAE("urn:openid:dcp:iae:openid4vp_presentation")
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandler.kt
@@ -38,8 +38,18 @@ class InteractiveAuthorizationHandler {
             //interaction types supported will be extracted from authmethods once we start supporting redirect-to-web
             val interactionTypesSupported = authorizationMethods
                 .filter { it.type != InteractionType.RedirectToWeb }
-                .map { it.type.value }
-
+                .flatMap {  
+                    if (it is AuthorizationMethod.PresentationDuringIssuance) {
+            listOf(
+                InteractionType.OpenId4VpPresentation.value,
+                InteractionType.OpenId4VpPresentationIAE.value
+            )
+        } else {
+            listOf(it.type.value)
+        }
+    }
+    .distinct()
+    
             if (interactionTypesSupported.isEmpty()) {
                 throw InteractiveAuthorizationException("No supported interaction types found in authorization methods")
             }
@@ -60,19 +70,19 @@ class InteractiveAuthorizationHandler {
                 )
             }
 
-            when (val type = extractTypeAndThrowIfError(response.body)) {
-                InteractionType.OpenId4VpPresentation.value ->
-                    handlePresentationInteraction(
-                        response.body,
-                        authorizationMethods,
-                        endpoint,
-                        traceabilityId
-                    )
+          when (val type = extractTypeAndThrowIfError(response.body)) {
+    InteractionType.OpenId4VpPresentation.value,
+    InteractionType.OpenId4VpPresentationIAE.value ->
+        handlePresentationInteraction(
+            response.body,
+            authorizationMethods,
+            endpoint,
+            traceabilityId
+        )
 
-                else ->
-                    throw InteractiveAuthorizationException("Unsupported interaction type: $type")
-            }
-
+    else ->
+        throw InteractiveAuthorizationException("Unsupported interaction type: $type")
+}
         } catch (e: InteractiveAuthorizationException) {
             logger.warning("Interactive authorization failed: ${e.message}")
             throw e

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt
@@ -56,8 +56,7 @@ class PresentationDuringIssuanceAuthorizationMethodService : AuthorizationMethod
         this.logger = Logger.getLogger(logTag)
     }
 
-    override fun type(): String = InteractionType.OpenId4VpPresentation.value
-
+   override fun type(): String = InteractionType.OpenId4VpPresentationIAE.value
     override suspend fun authorizeUser(
         requestData: AuthorizationRequestData
     ): AuthorizationResponse {
@@ -108,9 +107,18 @@ class PresentationDuringIssuanceAuthorizationMethodService : AuthorizationMethod
 
     private fun validatePresentationRequest(request: Map<String, Any>): AuthorizationRequest {
         val authorizationRequest = openId4vp.authenticateVerifier(request)
-        if (authorizationRequest.responseMode !in listOf("iar-post", "iar-post.jwt")) {
-            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
-        }
+       if (
+    authorizationRequest.responseMode !in listOf(
+        "iar-post",
+        "iar-post.jwt",
+        "iae_post",
+        "iae_post.jwt"
+    )
+) {
+    throw IllegalArgumentException(
+        "response_mode must be 'iar-post', 'iar-post.jwt', 'iae_post' or 'iae_post.jwt'"
+    )
+}
         return authorizationRequest
     }
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
@@ -1,5 +1,6 @@
 package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.presentationDuringIssuance
 
+import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler.InteractionType
 import com.google.gson.annotations.SerializedName
 import io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.response.InteractionResponse
 
@@ -16,10 +17,16 @@ data class PresentationInteractionResponse(
 
     override fun validate() {
 
-        if (type != "openid4vp_presentation") {
-            throw IllegalArgumentException("Invalid type: expected 'openid4vp_presentation'")
-        }
-
+     if (
+        type == InteractionType.OpenId4VpPresentation.value ||
+        type == InteractionType.OpenId4VpPresentationIAE.value
+    ) {
+        
+    } else {
+    throw IllegalArgumentException(
+        "Invalid type: expected '${InteractionType.OpenId4VpPresentation.value}' or '${InteractionType.OpenId4VpPresentationIAE.value}'"
+    )
+}
         if (openid4vpRequest.isEmpty()) {
             throw IllegalArgumentException("openid4vpRequest must not be empty")
         }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt
@@ -16,17 +16,13 @@ data class PresentationInteractionResponse(
 ) : InteractionResponse(status, type, authSession) {
 
     override fun validate() {
+        require(
+            type == InteractionType.OpenId4VpPresentation.value ||
+                type == InteractionType.OpenId4VpPresentationIAE.value
+        ) {
+            "Unsupported interaction type: $type. Expected OpenId4VpPresentation or OpenId4VpPresentationIAE."
+        }
 
-     if (
-        type == InteractionType.OpenId4VpPresentation.value ||
-        type == InteractionType.OpenId4VpPresentationIAE.value
-    ) {
-        
-    } else {
-    throw IllegalArgumentException(
-        "Invalid type: expected '${InteractionType.OpenId4VpPresentation.value}' or '${InteractionType.OpenId4VpPresentationIAE.value}'"
-    )
-}
         if (openid4vpRequest.isEmpty()) {
             throw IllegalArgumentException("openid4vpRequest must not be empty")
         }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerMetadata.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerMetadata.kt
@@ -16,5 +16,8 @@ data class AuthorizationServerMetadata(
     val authorizationEndpoint: String? = null,
 
     @SerializedName("interactive_authorization_endpoint")
-    val interactiveAuthorizationEndpoint: String? = null
+    val interactiveAuthorizationEndpoint: String? = null,
+
+    @SerializedName("require_interactive_authorization_request")
+val requireInteractiveAuthorizationRequest: Boolean? = null
 )

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerResolver.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerResolver.kt
@@ -40,10 +40,9 @@ class AuthorizationServerResolver {
     ): AuthorizationServerMetadata {
         val authorizationServers = issuerMetadata.authorizationServers
         return when {
-            authorizationServers?.size == 1 -> {
-                discoverAndValidate(authorizationServers.first(), expectedGrantType)
-            }
-
+           authorizationServers?.size == 1 -> {
+    discoverAndValidate(authorizationServers.first(), expectedGrantType)
+}
             !offerGrantAuthorizationServer.isNullOrBlank() -> {
                 discoverAndValidate(offerGrantAuthorizationServer, expectedGrantType)
             }
@@ -62,12 +61,20 @@ class AuthorizationServerResolver {
         authorizationServerUrl: String,
         expectedGrantType: String,
     ): AuthorizationServerMetadata {
-        val authorizationServerMetadata = AuthorizationServerDiscoveryService().discover(authorizationServerUrl)
 
-        if (authorizationServerUrl.isNotBlank() && authorizationServerMetadata.issuer != authorizationServerUrl) {
-            throw AuthorizationServerDiscoveryException("Issuer mismatch: Expected '$authorizationServerUrl', got '${authorizationServerMetadata.issuer}'")
-        }
+            val normalizedAuthorizationServerUrl = authorizationServerUrl.trim()
 
+val authorizationServerMetadata =
+    AuthorizationServerDiscoveryService().discover(normalizedAuthorizationServerUrl)
+
+if (
+    normalizedAuthorizationServerUrl.isNotEmpty() &&
+    authorizationServerMetadata.issuer != normalizedAuthorizationServerUrl
+) {
+    throw AuthorizationServerDiscoveryException(
+        "Issuer mismatch: Expected '$normalizedAuthorizationServerUrl', got '${authorizationServerMetadata.issuer}'"
+    )
+}
         if ((expectedGrantType !in ((authorizationServerMetadata.grantTypesSupported) ?: listOf(
                 GrantType.AUTHORIZATION_CODE.value, GrantType.IMPLICIT.value
             )) && expectedGrantType != GrantType.PRE_AUTHORIZED.value)

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerResolver.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerResolver.kt
@@ -39,10 +39,15 @@ class AuthorizationServerResolver {
         credentialIssuer: String,
     ): AuthorizationServerMetadata {
         val authorizationServers = issuerMetadata.authorizationServers
+
         return when {
-           authorizationServers?.size == 1 -> {
-    discoverAndValidate(authorizationServers.first(), expectedGrantType)
-}
+            authorizationServers?.size == 1 -> {
+                discoverAndValidate(
+                    authorizationServers.first(),
+                    expectedGrantType
+                )
+            }
+
             !offerGrantAuthorizationServer.isNullOrBlank() -> {
                 discoverAndValidate(offerGrantAuthorizationServer, expectedGrantType)
             }
@@ -62,24 +67,35 @@ class AuthorizationServerResolver {
         expectedGrantType: String,
     ): AuthorizationServerMetadata {
 
-            val normalizedAuthorizationServerUrl = authorizationServerUrl.trim()
+        val normalizedAuthorizationServerUrl = authorizationServerUrl.trim()
 
-val authorizationServerMetadata =
-    AuthorizationServerDiscoveryService().discover(normalizedAuthorizationServerUrl)
+        if (normalizedAuthorizationServerUrl.isEmpty()) {
+            throw AuthorizationServerDiscoveryException(
+                "Authorization server URL cannot be empty."
+            )
+        }
 
-if (
-    normalizedAuthorizationServerUrl.isNotEmpty() &&
-    authorizationServerMetadata.issuer != normalizedAuthorizationServerUrl
-) {
-    throw AuthorizationServerDiscoveryException(
-        "Issuer mismatch: Expected '$normalizedAuthorizationServerUrl', got '${authorizationServerMetadata.issuer}'"
-    )
-}
-        if ((expectedGrantType !in ((authorizationServerMetadata.grantTypesSupported) ?: listOf(
-                GrantType.AUTHORIZATION_CODE.value, GrantType.IMPLICIT.value
-            )) && expectedGrantType != GrantType.PRE_AUTHORIZED.value)
+        val authorizationServerMetadata =
+            AuthorizationServerDiscoveryService().discover(normalizedAuthorizationServerUrl)
+
+        if (authorizationServerMetadata.issuer != normalizedAuthorizationServerUrl) {
+            throw AuthorizationServerDiscoveryException(
+                "Issuer mismatch: Expected '$normalizedAuthorizationServerUrl', got '${authorizationServerMetadata.issuer}'"
+            )
+        }
+
+        if (
+            (expectedGrantType !in (
+                authorizationServerMetadata.grantTypesSupported
+                    ?: listOf(
+                        GrantType.AUTHORIZATION_CODE.value,
+                        GrantType.IMPLICIT.value
+                    )
+                ) && expectedGrantType != GrantType.PRE_AUTHORIZED.value)
         ) {
-            throw AuthorizationServerDiscoveryException("Grant type '$expectedGrantType' not supported by auth server.")
+            throw AuthorizationServerDiscoveryException(
+                "Grant type '$expectedGrantType' not supported by auth server."
+            )
         }
 
         return authorizationServerMetadata
@@ -98,7 +114,8 @@ if (
         }
 
         deferreds.firstNotNullOfOrNull { it.await() }
-            ?: throw AuthorizationServerDiscoveryException("None of the authorization servers responded with valid metadata.")
+            ?: throw AuthorizationServerDiscoveryException(
+                "None of the authorization servers responded with valid metadata."
+            )
     }
-
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowServiceTest.kt
@@ -89,6 +89,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns null
+            every { requireInteractiveAuthorizationRequest } returns false
         }
 
         every {
@@ -201,6 +202,7 @@ class AuthorizationCodeFlowServiceTest {
                 every { authorizationEndpoint } returns "https://auth.example.com"
                 every { tokenEndpoint } returns "https://token.example.com"
                 every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+             every { requireInteractiveAuthorizationRequest } returns false
             }
 
 
@@ -263,6 +265,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns null
             every { interactiveAuthorizationEndpoint } returns null
+             every { requireInteractiveAuthorizationRequest } returns false
         }
 
         every { resolvedIssuerMetadata.tokenEndpoint } returns null
@@ -290,6 +293,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
             every { tokenEndpoint } returns "https://token.example.com"
+            every { requireInteractiveAuthorizationRequest } returns false
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
@@ -420,6 +424,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+             every { requireInteractiveAuthorizationRequest } returns false
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
@@ -455,6 +460,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+        every { requireInteractiveAuthorizationRequest } returns false
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
@@ -496,7 +502,9 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+        every { requireInteractiveAuthorizationRequest } returns false
         }
+
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
 
@@ -536,6 +544,7 @@ class AuthorizationCodeFlowServiceTest {
             every { authorizationEndpoint } returns "https://auth.example.com"
             every { tokenEndpoint } returns "https://token.example.com"
             every { interactiveAuthorizationEndpoint } returns "https://auth.example.com/interactive"
+        every { requireInteractiveAuthorizationRequest } returns false
         }
 
         val mockHandler = mockkClass(InteractiveAuthorizationHandler::class)
@@ -651,4 +660,32 @@ class AuthorizationCodeFlowServiceTest {
 
             assertEquals("auth-code", response["code"])
         }
+
+@Test
+fun `should throw when interactive authorization is required but endpoint is missing`() = runBlocking {
+    coEvery {
+        anyConstructed<AuthorizationServerResolver>().resolveForAuthCode(any(), any())
+    } returns mockk {
+        every { authorizationEndpoint } returns "https://auth.example.com"
+        every { tokenEndpoint } returns "https://token.example.com"
+        every { interactiveAuthorizationEndpoint } returns null
+        every { requireInteractiveAuthorizationRequest } returns true
+    }
+
+    val exception = assertThrows<DownloadFailedException> {
+        AuthorizationCodeFlowService().requestCredentialsDraft13(
+            issuerMetadata = resolvedIssuerMetadata,
+            credentialConfigurationId = credentialConfigurationId,
+            clientMetadata = clientMetadata,
+            getTokenResponse = getTokenResponse,
+            getProofJwt = getProofJwt,
+            jwtProofAlgorithmsSupported = listOf("ES256"),
+            authorizationMethods = listOf(authorizationMethod)
+        )
+    }
+
+  assertTrue(
+    exception.message!!.contains("Missing interactive authorization endpoint")
+)
+}
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/handler/InteractiveAuthorizationHandlerTest.kt
@@ -1,11 +1,13 @@
 package io.mosip.vciclient.authorizationCodeFlow.interactiveAuthorization.handler
 
+import kotlin.test.assertTrue
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mosip.vciclient.authorizationCodeFlow.AuthorizationMethod
 import io.mosip.vciclient.authorizationCodeFlow.clientMetadata.ClientMetadata
@@ -32,6 +34,8 @@ class InteractiveAuthorizationHandlerTest {
 
     private val endpoint = "https://issuer.example.com/iar"
     private val credentialConfigId = "cred-config-id"
+
+    private val mapSlot = slot<Map<String, String>>()
 
     private val clientMetadata = ClientMetadata(
         clientId = "wallet-client",
@@ -198,6 +202,7 @@ class InteractiveAuthorizationHandlerTest {
             )
         }
     }
+    
 
     @Test
     fun `should throw error when OpenID4VP response parsing fails`() = runTest {
@@ -297,4 +302,52 @@ class InteractiveAuthorizationHandlerTest {
 
         assertEquals("Failed to authorize via interaction: known error", ex.message)
     }
+
+@Test
+fun `should include both OpenID4VP and IAE interaction types in initial IAR request`() = runTest {
+
+    val responseBody = mockPresentationInteractionResponse
+
+    mockkStatic(Base64::class)
+    every { Base64.encodeToString(any<ByteArray>(), any()) } returns "b64"
+
+    every {
+        NetworkManager.sendRequest(
+            url = endpoint,
+            method = HttpMethod.POST,
+            bodyParams = capture(mapSlot),
+            headers = any()
+        )
+    } returns NetworkResponse(responseBody, null)
+
+    val expected = mockk<AuthorizationResponse>()
+
+    val presentationMethod =
+        AuthorizationMethod.PresentationDuringIssuance(
+            selectCredentialsForPresentation = mockk(relaxed = true),
+            signVerifiablePresentation = mockk(relaxed = true)
+        )
+
+    mockkConstructor(PresentationDuringIssuanceAuthorizationMethodService::class)
+
+    coEvery {
+        anyConstructed<PresentationDuringIssuanceAuthorizationMethodService>()
+            .authorizeUser(any())
+    } returns expected
+
+    handler.handle(
+        endpoint = endpoint,
+        clientMetadata = clientMetadata,
+        credentialConfigurationId = credentialConfigId,
+        authorizationMethods = listOf(presentationMethod),
+        pkceSession = pkceSession
+    )
+
+   val interactionTypes = mapSlot.captured["interaction_types_supported"]
+
+   assertEquals(
+    "${InteractionType.OpenId4VpPresentation.value},${InteractionType.OpenId4VpPresentationIAE.value}",
+    interactionTypes
+)
+}
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTest.kt
@@ -242,7 +242,7 @@ class PresentationDuringIssuanceAuthorizationMethodServiceTest {
 
         verify(exactly = 1) {
             mockOvp.constructErrorInfo(
-                match { it.message == "response_mode must be 'iar-post' or 'iar-post.jwt'" }
+                match { it.message == "response_mode must be 'iar-post', 'iar-post.jwt', 'iae_post' or 'iae_post.jwt'" }
             )
         }
         coVerify(exactly = 0) { mockOvp.constructUnsignedVPToken(any()) }


### PR DESCRIPTION
OpenID4VCI 1.1 interactive authorization support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for IAE-based OpenID4VP presentation interactions.
  * Expanded supported presentation response modes to include `iae_post` and `iae_post.jwt`.
  * Read and applies `require_interactive_authorization_request` from authorization server metadata.
* **Bug Fixes**
  * Improved error handling when interactive authorization is required but the interactive endpoint is missing.
  * Refined fallback behavior to only fall back when permitted after interactive failures.
  * Enhanced validation to accept both standard and IAE interaction types.
  * Authorization server URLs are now normalized (trimmed) and empty values fail fast.
* **Tests**
  * Updated and added unit tests covering expanded interaction support and required-endpoint-missing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->