### PR TITLE
fix(discovery): build auth-server well-known URL per RFC 8414

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
@@ -7,6 +7,7 @@ import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.net.URI
 import java.util.logging.Logger
 
 private const val OAUTH_WELL_KNOWN_URI_SUFFIX = "/.well-known/oauth-authorization-server"
@@ -17,41 +18,64 @@ class AuthorizationServerDiscoveryService {
 
     /**
      * Discovers the authorization server metadata by querying the well-known endpoints.
-     * Some authorization servers will choose to support "openid-configuration" well-known suffix while some will choose to go with default "oauth-authorization-server" suffix.
+     * Some authorization servers support the "openid-configuration" suffix while others use the
+     * default "oauth-authorization-server" suffix, so both are attempted.
+     *
+     * Per RFC 8414 section 3, when the issuer has a path component the well-known suffix is
+     * inserted between the authority and the path; the legacy form (suffix appended to the issuer)
+     * is kept as a fallback for servers that expose it that way.
      * reference - https://datatracker.ietf.org/doc/html/rfc8414#section-3
      */
     suspend fun discover(baseUrl: String): AuthorizationServerMetadata = withContext(Dispatchers.IO) {
-        val oauthUrl = "$baseUrl$OAUTH_WELL_KNOWN_URI_SUFFIX"
-        val openidUrl = "$baseUrl$OPENID_WELL_KNOWN_URI_SUFFIX"
-
-        try {
-            val oauthResponse = NetworkManager.sendRequest(
-                url = oauthUrl,
-                method = HttpMethod.GET,
-                timeoutMillis = Constants.DEFAULT_NETWORK_TIMEOUT_IN_MILLIS
-            )
-            if (oauthResponse.body.isNotBlank()) {
-                JsonUtils.deserialize(oauthResponse.body, AuthorizationServerMetadata::class.java)
-                    ?.let { return@withContext it }
+        for (wellKnownUrl in buildCandidateWellKnownUrls(baseUrl)) {
+            try {
+                val response = NetworkManager.sendRequest(
+                    url = wellKnownUrl,
+                    method = HttpMethod.GET,
+                    timeoutMillis = Constants.DEFAULT_NETWORK_TIMEOUT_IN_MILLIS
+                )
+                if (response.body.isNotBlank()) {
+                    JsonUtils.deserialize(response.body, AuthorizationServerMetadata::class.java)
+                        ?.let { return@withContext it }
+                }
+            } catch (e: Exception) {
+                logger.warning(
+                    "Authorization server discovery failed at $wellKnownUrl, trying next candidate: ${e.message}"
+                )
             }
-        } catch (e: Exception) {
-            logger.warning("OAuth discovery failed, trying OpenID discovery: ${e.message}")
         }
 
-        try {
-            val openidResponse = NetworkManager.sendRequest(
-                url = openidUrl,
-                method = HttpMethod.GET,
-                timeoutMillis = Constants.DEFAULT_NETWORK_TIMEOUT_IN_MILLIS
-            )
-            if (openidResponse.body.isNotBlank()) {
-                JsonUtils.deserialize(openidResponse.body, AuthorizationServerMetadata::class.java)
-                    ?.let { return@withContext it }
+        throw AuthorizationServerDiscoveryException(
+            "Failed to discover authorization server metadata at all well-known endpoints"
+        )
+    }
+
+    /**
+     * Candidate well-known URLs in priority order. When the base URL has a path component the
+     * suffix is inserted between the authority and the path (RFC 8414); the legacy suffix-append
+     * form is always added as a fallback for servers that expose it that way.
+     */
+    internal fun buildCandidateWellKnownUrls(baseUrl: String): List<String> {
+        val normalized = baseUrl.trimEnd('/')
+        val candidates = mutableListOf<String>()
+
+        runCatching {
+            val uri = URI(normalized)
+            val scheme = uri.scheme
+            val host = uri.host
+            if (scheme != null && host != null) {
+                val port = if (uri.port != -1) ":${uri.port}" else ""
+                val authority = "$scheme://$host$port"
+                val path = (uri.path ?: "").trimEnd('/')
+                if (path.isNotEmpty()) {
+                    candidates.add("$authority$OAUTH_WELL_KNOWN_URI_SUFFIX$path")
+                    candidates.add("$authority$OPENID_WELL_KNOWN_URI_SUFFIX$path")
+                }
             }
-        } catch (e: Exception) {
-            logger.warning("OpenID discovery also failed: ${e.message}")
         }
 
-        throw AuthorizationServerDiscoveryException("Failed to discover authorization server metadata at both endpoints")
+        candidates.add("$normalized$OAUTH_WELL_KNOWN_URI_SUFFIX")
+        candidates.add("$normalized$OPENID_WELL_KNOWN_URI_SUFFIX")
+        return candidates
     }
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
@@ -17,14 +17,9 @@ class AuthorizationServerDiscoveryService {
     private val logger = Logger.getLogger(javaClass.simpleName)
 
     /**
-     * Discovers the authorization server metadata by querying the well-known endpoints.
-     * Some authorization servers support the "openid-configuration" suffix while others use the
-     * default "oauth-authorization-server" suffix, so both are attempted.
-     *
-     * Per RFC 8414 section 3, when the issuer has a path component the well-known suffix is
-     * inserted between the authority and the path; the legacy form (suffix appended to the issuer)
-     * is kept as a fallback for servers that expose it that way.
-     * reference - https://datatracker.ietf.org/doc/html/rfc8414#section-3
+     * Discovers the authorization server metadata by querying the well-known endpoints
+     * (oauth-authorization-server first, then openid-configuration), trying each candidate URL
+     * until one returns parseable metadata.
      */
     suspend fun discover(baseUrl: String): AuthorizationServerMetadata = withContext(Dispatchers.IO) {
         for (wellKnownUrl in buildCandidateWellKnownUrls(baseUrl)) {
@@ -51,24 +46,24 @@ class AuthorizationServerDiscoveryService {
     }
 
     /**
-     * Candidate well-known URLs in priority order. When the base URL has a path component the
-     * suffix is inserted between the authority and the path (RFC 8414); the legacy suffix-append
-     * form is always added as a fallback for servers that expose it that way.
+     * Candidate well-known URLs in priority order: the [WellKnownUrl] inserted form followed by
+     * the legacy append form, for both well-known suffixes.
      */
     internal fun buildCandidateWellKnownUrls(baseUrl: String): List<String> {
         val normalized = baseUrl.trimEnd('/')
         val candidates = mutableListOf<String>()
 
-        // RFC 8414 inserted form (a no-op vs. append when the base URL has no path).
         runCatching {
-            candidates.add(WellKnownUrl.withInsertedSuffix(normalized, OAUTH_WELL_KNOWN_URI_SUFFIX))
-            candidates.add(WellKnownUrl.withInsertedSuffix(normalized, OPENID_WELL_KNOWN_URI_SUFFIX))
+            candidates.add(WellKnownUrl.insertSuffix(normalized, OAUTH_WELL_KNOWN_URI_SUFFIX))
+            candidates.add(WellKnownUrl.insertSuffix(normalized, OPENID_WELL_KNOWN_URI_SUFFIX))
         }
 
-        // Legacy append form kept as a fallback.
-        candidates.add("$normalized$OAUTH_WELL_KNOWN_URI_SUFFIX")
-        candidates.add("$normalized$OPENID_WELL_KNOWN_URI_SUFFIX")
+        val appendedOauthUrl = "$normalized$OAUTH_WELL_KNOWN_URI_SUFFIX"
+        if (appendedOauthUrl !in candidates) {
+            candidates.add(appendedOauthUrl)
+            candidates.add("$normalized$OPENID_WELL_KNOWN_URI_SUFFIX")
+        }
 
-        return candidates.distinct()
+        return candidates
     }
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryService.kt
@@ -1,13 +1,13 @@
 package io.mosip.vciclient.authorizationServer
 
 import io.mosip.vciclient.common.JsonUtils
+import io.mosip.vciclient.common.WellKnownUrl
 import io.mosip.vciclient.constants.Constants
 import io.mosip.vciclient.exception.AuthorizationServerDiscoveryException
 import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.net.URI
 import java.util.logging.Logger
 
 private const val OAUTH_WELL_KNOWN_URI_SUFFIX = "/.well-known/oauth-authorization-server"
@@ -59,23 +59,16 @@ class AuthorizationServerDiscoveryService {
         val normalized = baseUrl.trimEnd('/')
         val candidates = mutableListOf<String>()
 
+        // RFC 8414 inserted form (a no-op vs. append when the base URL has no path).
         runCatching {
-            val uri = URI(normalized)
-            val scheme = uri.scheme
-            val host = uri.host
-            if (scheme != null && host != null) {
-                val port = if (uri.port != -1) ":${uri.port}" else ""
-                val authority = "$scheme://$host$port"
-                val path = (uri.path ?: "").trimEnd('/')
-                if (path.isNotEmpty()) {
-                    candidates.add("$authority$OAUTH_WELL_KNOWN_URI_SUFFIX$path")
-                    candidates.add("$authority$OPENID_WELL_KNOWN_URI_SUFFIX$path")
-                }
-            }
+            candidates.add(WellKnownUrl.withInsertedSuffix(normalized, OAUTH_WELL_KNOWN_URI_SUFFIX))
+            candidates.add(WellKnownUrl.withInsertedSuffix(normalized, OPENID_WELL_KNOWN_URI_SUFFIX))
         }
 
+        // Legacy append form kept as a fallback.
         candidates.add("$normalized$OAUTH_WELL_KNOWN_URI_SUFFIX")
         candidates.add("$normalized$OPENID_WELL_KNOWN_URI_SUFFIX")
-        return candidates
+
+        return candidates.distinct()
     }
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
@@ -14,7 +14,7 @@ object WellKnownUrl {
      * [baseUrl]. e.g. `https://host/tenant` + `/.well-known/x` -> `https://host/.well-known/x/tenant`.
      * When [baseUrl] has no path this is equivalent to appending the suffix.
      */
-    fun withInsertedSuffix(baseUrl: String, suffix: String): String {
+    fun insertSuffix(baseUrl: String, suffix: String): String {
         val uri = URI(baseUrl)
         val path = uri.path?.trimEnd('/').orEmpty()
         return "${uri.scheme}://${uri.authority}$suffix$path"

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
@@ -16,7 +16,9 @@ object WellKnownUrl {
      */
     fun insertSuffix(baseUrl: String, suffix: String): String {
         val uri = URI(baseUrl)
-        val path = uri.path?.trimEnd('/').orEmpty()
+        // Use rawPath so an escaped separator (e.g. /tenant%2Falpha) is not decoded into a
+        // different path that would resolve to a different metadata endpoint.
+        val path = uri.rawPath?.trimEnd('/').orEmpty()
         return "${uri.scheme}://${uri.authority}$suffix$path"
     }
 }

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/common/WellKnownUrl.kt
@@ -1,0 +1,22 @@
+package io.mosip.vciclient.common
+
+import java.net.URI
+
+/**
+ * Shared construction of `.well-known` metadata URLs, kept in one place so the
+ * authorization-server discovery and issuer-metadata paths cannot drift apart in this
+ * security-sensitive URL handling.
+ */
+object WellKnownUrl {
+
+    /**
+     * RFC 8414 section 3: insert the well-known [suffix] between the authority and the path of
+     * [baseUrl]. e.g. `https://host/tenant` + `/.well-known/x` -> `https://host/.well-known/x/tenant`.
+     * When [baseUrl] has no path this is equivalent to appending the suffix.
+     */
+    fun withInsertedSuffix(baseUrl: String, suffix: String): String {
+        val uri = URI(baseUrl)
+        val path = uri.path?.trimEnd('/').orEmpty()
+        return "${uri.scheme}://${uri.authority}$suffix$path"
+    }
+}

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
@@ -141,7 +141,7 @@ class IssuerMetadataService {
     }
 
     private fun buildWellKnownUrl(credentialIssuer: String): String =
-        WellKnownUrl.withInsertedSuffix(credentialIssuer, CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX)
+        WellKnownUrl.insertSuffix(credentialIssuer, CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX)
 
     private fun buildDraft13WellKnownUrl(credentialIssuer: String): String {
         val normalizedIssuer = credentialIssuer.trimEnd('/')

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt
@@ -1,6 +1,7 @@
 package io.mosip.vciclient.issuerMetadata
 
 import io.mosip.vciclient.common.JsonUtils
+import io.mosip.vciclient.common.WellKnownUrl
 import io.mosip.vciclient.constants.CredentialFormat
 import io.mosip.vciclient.constants.OID4VCIVersion
 import io.mosip.vciclient.exception.IssuerMetadataFetchException
@@ -9,7 +10,6 @@ import io.mosip.vciclient.networkManager.HttpMethod
 import io.mosip.vciclient.networkManager.NetworkManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.net.URI
 
 private const val CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX = "/.well-known/openid-credential-issuer"
 
@@ -140,11 +140,8 @@ class IssuerMetadataService {
         }
     }
 
-    private fun buildWellKnownUrl(credentialIssuer: String): String {
-        val uri = URI(credentialIssuer)
-        val path = uri.path?.trimEnd('/').orEmpty()
-        return "${uri.scheme}://${uri.authority}$CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX$path"
-    }
+    private fun buildWellKnownUrl(credentialIssuer: String): String =
+        WellKnownUrl.withInsertedSuffix(credentialIssuer, CREDENTIAL_ISSUER_WELL_KNOWN_URI_SUFFIX)
 
     private fun buildDraft13WellKnownUrl(credentialIssuer: String): String {
         val normalizedIssuer = credentialIssuer.trimEnd('/')

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryServiceTest.kt
@@ -92,7 +92,7 @@ class AuthorizationServerDiscoveryServiceTest {
         }
 
         assertTrue(
-            ex.message.contains("Failed to discover authorization server metadata at both endpoints")
+            ex.message.contains("Failed to discover authorization server metadata at all well-known endpoints")
         )
     }
 
@@ -111,7 +111,71 @@ class AuthorizationServerDiscoveryServiceTest {
         }
 
         assertTrue(
-            ex.message.contains("Failed to discover authorization server metadata at both endpoints")
+            ex.message.contains("Failed to discover authorization server metadata at all well-known endpoints")
         )
+    }
+
+    @Test
+    fun `buildCandidateWellKnownUrls inserts suffix before path per RFC 8414 for path-based issuer`() {
+        val candidates = AuthorizationServerDiscoveryService()
+            .buildCandidateWellKnownUrls("https://host.example.com/v1/esignet")
+
+        assertEquals(
+            listOf(
+                "https://host.example.com/.well-known/oauth-authorization-server/v1/esignet",
+                "https://host.example.com/.well-known/openid-configuration/v1/esignet",
+                "https://host.example.com/v1/esignet/.well-known/oauth-authorization-server",
+                "https://host.example.com/v1/esignet/.well-known/openid-configuration"
+            ),
+            candidates
+        )
+    }
+
+    @Test
+    fun `buildCandidateWellKnownUrls only appends when issuer has no path`() {
+        val candidates = AuthorizationServerDiscoveryService()
+            .buildCandidateWellKnownUrls("https://host.example.com")
+
+        assertEquals(
+            listOf(
+                "https://host.example.com/.well-known/oauth-authorization-server",
+                "https://host.example.com/.well-known/openid-configuration"
+            ),
+            candidates
+        )
+    }
+
+    @Test
+    fun `buildCandidateWellKnownUrls preserves port and trims trailing slash`() {
+        val candidates = AuthorizationServerDiscoveryService()
+            .buildCandidateWellKnownUrls("https://host.example.com:8443/tenant/")
+
+        assertTrue(
+            candidates.contains("https://host.example.com:8443/.well-known/oauth-authorization-server/tenant")
+        )
+        assertTrue(
+            candidates.contains("https://host.example.com:8443/tenant/.well-known/oauth-authorization-server")
+        )
+    }
+
+    @Test
+    fun `discover uses RFC 8414 inserted well-known url for path-based issuer`() = runBlocking {
+        val issuer = "https://host.example.com/v1/esignet"
+        val insertedOauthUrl =
+            "https://host.example.com/.well-known/oauth-authorization-server/v1/esignet"
+        val expected = AuthorizationServerMetadata(
+            issuer = "x", authorizationEndpoint = "https://host.example.com/auth"
+        )
+
+        every {
+            NetworkManager.sendRequest(insertedOauthUrl, HttpMethod.GET, any(), any(), 10000)
+        } returns io.mosip.vciclient.networkManager.NetworkResponse(mockResponseBody, null)
+
+        every {
+            JsonUtils.deserialize(mockResponseBody, AuthorizationServerMetadata::class.java)
+        } returns expected
+
+        val result = AuthorizationServerDiscoveryService().discover(issuer)
+        assertEquals(expected.authorizationEndpoint, result.authorizationEndpoint)
     }
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryServiceTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/authorizationServer/AuthorizationServerDiscoveryServiceTest.kt
@@ -178,4 +178,37 @@ class AuthorizationServerDiscoveryServiceTest {
         val result = AuthorizationServerDiscoveryService().discover(issuer)
         assertEquals(expected.authorizationEndpoint, result.authorizationEndpoint)
     }
+
+    @Test
+    fun `discover falls back to legacy appended well-known url for path-based issuer`() = runBlocking {
+        val issuer = "https://host.example.com/v1/esignet"
+        val insertedOauthUrl =
+            "https://host.example.com/.well-known/oauth-authorization-server/v1/esignet"
+        val insertedOpenidUrl =
+            "https://host.example.com/.well-known/openid-configuration/v1/esignet"
+        val legacyOauthUrl =
+            "https://host.example.com/v1/esignet/.well-known/oauth-authorization-server"
+        val expected = AuthorizationServerMetadata(
+            issuer = "x", authorizationEndpoint = "https://host.example.com/auth"
+        )
+
+        every {
+            NetworkManager.sendRequest(insertedOauthUrl, HttpMethod.GET, any(), any(), 10000)
+        } throws RuntimeException("inserted oauth down")
+
+        every {
+            NetworkManager.sendRequest(insertedOpenidUrl, HttpMethod.GET, any(), any(), 10000)
+        } throws RuntimeException("inserted openid down")
+
+        every {
+            NetworkManager.sendRequest(legacyOauthUrl, HttpMethod.GET, any(), any(), 10000)
+        } returns io.mosip.vciclient.networkManager.NetworkResponse(mockResponseBody, null)
+
+        every {
+            JsonUtils.deserialize(mockResponseBody, AuthorizationServerMetadata::class.java)
+        } returns expected
+
+        val result = AuthorizationServerDiscoveryService().discover(issuer)
+        assertEquals(expected.authorizationEndpoint, result.authorizationEndpoint)
+    }
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
@@ -1,0 +1,40 @@
+package io.mosip.vciclient.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WellKnownUrlTest {
+
+    @Test
+    fun `inserts suffix between authority and path per RFC 8414`() {
+        assertEquals(
+            "https://host.example.com/.well-known/openid-credential-issuer/v1/issuer",
+            WellKnownUrl.withInsertedSuffix(
+                "https://host.example.com/v1/issuer",
+                "/.well-known/openid-credential-issuer"
+            )
+        )
+    }
+
+    @Test
+    fun `appends suffix when there is no path`() {
+        assertEquals(
+            "https://host.example.com/.well-known/oauth-authorization-server",
+            WellKnownUrl.withInsertedSuffix(
+                "https://host.example.com",
+                "/.well-known/oauth-authorization-server"
+            )
+        )
+    }
+
+    @Test
+    fun `preserves port and trims trailing path slash`() {
+        assertEquals(
+            "https://host.example.com:8443/.well-known/openid-configuration/tenant",
+            WellKnownUrl.withInsertedSuffix(
+                "https://host.example.com:8443/tenant/",
+                "/.well-known/openid-configuration"
+            )
+        )
+    }
+}

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
@@ -37,4 +37,15 @@ class WellKnownUrlTest {
             )
         )
     }
+
+    @Test
+    fun `preserves percent-encoded path segments`() {
+        assertEquals(
+            "https://host.example.com/.well-known/openid-configuration/tenant%2Falpha",
+            WellKnownUrl.insertSuffix(
+                "https://host.example.com/tenant%2Falpha",
+                "/.well-known/openid-configuration"
+            )
+        )
+    }
 }

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/common/WellKnownUrlTest.kt
@@ -9,7 +9,7 @@ class WellKnownUrlTest {
     fun `inserts suffix between authority and path per RFC 8414`() {
         assertEquals(
             "https://host.example.com/.well-known/openid-credential-issuer/v1/issuer",
-            WellKnownUrl.withInsertedSuffix(
+            WellKnownUrl.insertSuffix(
                 "https://host.example.com/v1/issuer",
                 "/.well-known/openid-credential-issuer"
             )
@@ -20,7 +20,7 @@ class WellKnownUrlTest {
     fun `appends suffix when there is no path`() {
         assertEquals(
             "https://host.example.com/.well-known/oauth-authorization-server",
-            WellKnownUrl.withInsertedSuffix(
+            WellKnownUrl.insertSuffix(
                 "https://host.example.com",
                 "/.well-known/oauth-authorization-server"
             )
@@ -31,7 +31,7 @@ class WellKnownUrlTest {
     fun `preserves port and trims trailing path slash`() {
         assertEquals(
             "https://host.example.com:8443/.well-known/openid-configuration/tenant",
-            WellKnownUrl.withInsertedSuffix(
+            WellKnownUrl.insertSuffix(
                 "https://host.example.com:8443/tenant/",
                 "/.well-known/openid-configuration"
             )


### PR DESCRIPTION
AuthorizationServerDiscoveryService appended the well-known suffix to the issuer base URL, so an authorization server whose base URL has a path component (e.g. `https://host/v1/esignet`) was probed at the wrong URL and discovery failed.

- Insert the well-known suffix between the authority and the path per RFC 8414 §3, keeping the legacy append form as a fallback, and try `oauth-authorization-server` then `openid-configuration` for each candidate.
- Extract a shared `WellKnownUrl.insertSuffix` helper reused by `IssuerMetadataService.buildWellKnownUrl` so this security-sensitive URL construction cannot diverge.
- Mirrors the iOS client behaviour.

Tests added for the candidate construction and the shared helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization server discovery for issuers hosted under URL paths.
  * Added support for multiple well-known endpoint formats and fallback discovery.
  * Preserved ports and normalized trailing slashes in metadata URLs.
  * Improved credential issuer metadata URL construction for path-based issuers.
* **Tests**
  * Expanded coverage for URL construction, endpoint fallback, path handling, ports, and trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->