### PR TITLE
docs: udpate docs - VCI 1.0

### DIFF
--- a/docs/adr/0001-openid4vci-v1-migration.md
+++ b/docs/adr/0001-openid4vci-v1-migration.md
@@ -1,0 +1,399 @@
+# ADR-0001: OpenID4VCI 1.0 Migration with Draft-13 Compatibility
+
+- Status: Accepted
+- Date: 2026-03-30
+
+## Context
+
+`VCIClient` originally implemented the OpenID4VCI specification Draft-13:
+
+- single proof callback
+- single credential response
+- no issuer nonce endpoint handling
+- request/response models shaped around Draft-13
+
+With the release of the OpenID4VCI specification version 1.0, this library needs to be updated to support it, while maintaining interoperability with issuers that are compliant with Draft-13.
+
+
+The main constraints are:
+
+- Draft-13 issuers must continue to work
+- the public API should be smaller and easier to integrate
+- 1.0 support should not require a heavy rewrite
+- internal design should remain close to the existing flow/service/handler architecture
+
+## Decision
+
+The library exposes only the OpenID4VCI 1.0-shaped public APIs in `1.0.0` and keeps Draft-13 compatibility as an internal routing concern.
+
+### Public API surface
+
+The public credential download surface is:
+
+- `fetchCredentialsUsingCredentialOffer(... getProofs = ProofsCallback ...) -> CredentialResponse`
+- `fetchCredentialsFromTrustedIssuer(... getProofs = ProofsCallback ...) -> CredentialResponse`
+
+Supporting public types:
+
+- `CredentialRequestProofs`
+- `CredentialResponse`
+- `CredentialResponseDraft13`
+- `OID4VCIVersion`
+
+Removed from the public surface (1.0.0):
+
+- All Draft-13-shaped `ProofJwtCallback` download APIs
+- All deprecated wrapper methods (e.g. `requestCredentials(getProofJwt = ...)`)
+- Low-level request APIs and their `IssuerMeta` DTO
+
+### Internal routing rule
+
+At the internal level:
+
+- the default method names represent the primary 1.0 path
+- explicit `Draft13` methods represent the compatibility path
+- public APIs call the default methods and allow metadata-based routing
+- when metadata indicates Draft-13, the compatibility route remains internal and the response is normalized before returning to the caller
+
+This keeps the public contract centered on 1.0 while isolating Draft-13 behavior in clearly named compatibility methods.
+
+## Public interface
+
+### Callback contract
+
+Public callback:
+
+```kotlin
+public typealias ProofsCallback = suspend (
+    issuerUrl: String,
+    cNonce: String?,
+    proofSigningAlgorithmsSupported: List<String>
+) -> CredentialRequestProofs
+```
+
+Current `CredentialRequestProofs` supports:
+
+- `jwt: List<String>?`
+
+This is intentionally plural at the wire boundary even though the current Draft-13 bridge still extracts the first JWT when talking to an older issuer.
+
+### Response contract
+
+Public response:
+
+- `CredentialResponse`
+- exposes plural `credentials`
+- does not expose a synthetic singular `credential`
+
+When the new API talks to a Draft-13 issuer, the internal Draft-13 response is normalized into:
+
+```kotlin
+CredentialResponse(credentials = listOf(draft13Credential), ...)
+```
+
+This keeps the public contract stable while avoiding a hybrid response model.
+
+## Architecture
+
+### Top-level component model
+
+```mermaid
+flowchart TD
+    A[VCIClient] --> B[CredentialOfferFlowHandler]
+    A --> C[TrustedIssuerFlowHandler]
+
+    B --> D[IssuerMetadataService]
+    B --> E[PreAuthCodeFlowService]
+    B --> F[AuthorizationCodeFlowService]
+
+    C --> D
+    C --> F
+
+    E --> G[AuthorizationServerResolver]
+    E --> H[TokenService]
+    E --> I[CredentialRequestExecutor]
+    E --> J[NonceService]
+
+    F --> G
+    F --> H
+    F --> I
+    F --> J
+
+    I --> K[CredentialRequestFactory]
+    I --> L[CredentialRequestFactoryDraft13]
+```
+
+### Internal path ownership
+
+```mermaid
+flowchart LR
+    A[Public 1.0 APIs] --> B[download/request default]
+
+    B --> C{Issuer metadata version}
+
+    C -->|v1| D[1.0 request encoder]
+    C -->|draft13| E[Draft-13 request encoder]
+
+    D --> F[1.0 response]
+    E --> G[Draft-13 response]
+
+    G --> H[Normalize to CredentialResponse]
+```
+
+## Detailed routing
+
+### Public API routing
+
+The public APIs are metadata-aware.
+
+Flow:
+
+1. fetch issuer metadata
+2. resolve `specVersion`
+3. if `v1`, use the primary 1.0 path
+4. if `draft13`, use the Draft-13 path internally
+5. return `CredentialResponse` to the caller in either case
+
+### Version detection policy
+
+`IssuerMetadataService` resolves `IssuerMetadata.specVersion` from issuer metadata hints.
+
+Current implementation:
+
+- if `nonce_endpoint` exists and is non-empty, classify as `v1`
+- if credential configuration contains `credential_metadata`, classify as `v1`
+- if credential configuration contains `display`, classify as `draft13`
+- otherwise default to `v1`
+
+Defaulting to `v1` is deliberate. The public API surface is 1.0-first, and inconclusive metadata should not force a legacy route.
+
+## Request model changes
+
+### Draft-13 request shape
+
+Draft-13 requests use singular proof:
+
+```json
+{
+  "format": "jwt_vc_json",
+  "credential_definition": { "...": "..." },
+  "proof": {
+    "proof_type": "jwt",
+    "jwt": "eyJ..."
+  }
+}
+```
+
+### 1.0 request shape
+
+1.0 requests use plural proofs and identify the credential by configuration id:
+
+```json
+{
+  "credential_configuration_id": "UniversityDegreeCredential",
+  "proofs": {
+    "jwt": ["eyJ..."]
+  }
+}
+```
+
+### Format handling
+
+The request-structure split is now explicit:
+
+- the 1.0 path is format-agnostic at the request body level
+- all supported formats use the same `credential_configuration_id` + `proofs` request shape
+- Draft-13 remains format-specific and continues to use per-format request builders
+- this avoids reusing the 1.0 request model inside the Draft-13 path and preserves Draft-13 builder validation
+
+### Factory design
+
+The request factories are separated by protocol version and request model:
+
+- `CredentialRequestFactory`
+- `CredentialRequestFactoryDraft13`
+
+The 1.0 factory is now isolated to the 1.0 request model:
+
+- validates that the proof collection is not empty
+- builds the request body using `credential_configuration_id` and `proofs`
+
+The Draft-13 factory is also isolated to the legacy request model:
+
+- validates that the proof is a non-empty JWT proof
+- dispatches to existing per-format Draft-13 builders
+- keeps Draft-13-specific request validation inside those builders
+
+This preserves the pre-migration Draft-13 validation behavior while keeping the 1.0 request path aligned with the current `credential_configuration_id`-based contract.
+
+## Response model changes
+
+### Draft-13 response shape
+
+```json
+{
+  "credential": { "...": "..." }
+}
+```
+
+### 1.0 response shape
+
+```json
+{
+  "credentials": [
+    { "...": "..." }
+  ]
+}
+```
+
+### Normalization policy
+
+- do not synthesize `credential` inside `CredentialResponse`
+- do not expose a hybrid response model
+- if the public API talks to a Draft-13 issuer, wrap the Draft-13 credential into a one-item `credentials` array
+
+## Nonce handling
+
+OpenID4VCI 1.0 introduces explicit nonce endpoint support.
+
+Nonce resolution is now:
+
+1. for Draft-13 route:
+   - use `NonceService.extractNonceFromTokenResponse()` to extract `c_nonce` from the token response
+   - fail if the Draft-13 flow requires a nonce and it is missing
+2. for 1.0 route:
+   - fetch nonce using `NonceService.fetchNonce()` from issuer metadata `nonce_endpoint`
+
+This keeps the old route behavior intact while enabling 1.0 proof generation.
+
+
+## Sequences
+
+### Sequence: new API on 1.0 issuer
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Client as VCIClient
+    participant Handler as *FlowHandler
+    participant Metadata as IssuerMetadataService
+    participant Service as *FlowService
+    participant Nonce as NonceService
+    participant Exec as CredentialRequestExecutor
+
+    App->>Client: fetchCredentialsUsingCredentialOffer(... getProofs ...)
+    Client->>Handler: downloadCredentials(...)
+    Handler->>Metadata: fetchIssuerMetadataResult(...)
+    Metadata-->>Handler: specVersion = v1
+    Handler->>Service: requestCredentials(...)
+    Service->>Nonce: fetchNonce(...)
+    Nonce-->>Service: nonce
+    Service->>App: getProofs(issuer, nonce, algs)
+    App-->>Service: CredentialRequestProofs
+    Service->>Exec: requestCredential(...)
+    Exec-->>Service: CredentialResponse
+    Service-->>Handler: CredentialResponse
+    Handler-->>Client: CredentialResponse
+    Client-->>App: CredentialResponse
+```
+
+### Sequence: new API on Draft-13 issuer
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Client as VCIClient
+    participant Handler as *FlowHandler
+    participant Metadata as IssuerMetadataService
+    participant Service as *FlowService Draft13
+    participant Exec as CredentialRequestExecutor
+
+    App->>Client: fetchCredentialsUsingCredentialOffer(... getProofs ...)
+    Client->>Handler: downloadCredentials(...)
+    Handler->>Metadata: fetchIssuerMetadataResult(...)
+    Metadata-->>Handler: specVersion = draft13
+    Handler->>App: getProofs(issuer, c_nonce, algs)
+    App-->>Handler: CredentialRequestProofs
+    Note over Handler: first jwt proof is extracted
+    Handler->>Service: requestCredentialsDraft13(...)
+    Service->>Exec: requestCredentialDraft13(...)
+    Exec-->>Service: CredentialResponse
+    Service-->>Handler: CredentialResponse
+    Handler->>Handler: wrap into CredentialResponse(credentials = listOf(credential))
+    Handler-->>Client: CredentialResponse
+    Client-->>App: CredentialResponse
+```
+
+## Consequences
+
+### Positive
+
+- existing integrations are preserved
+- legacy API behavior is stable and explicit
+- new API exposes a cleaner 1.0 contract
+- future removal of Draft-13 is straightforward because compatibility code is isolated behind `Draft13` methods
+- request and response wire-model differences are explicit instead of hidden
+
+### Negative
+
+- the public API may still run on Draft-13 internally, which adds normalization logic
+- metadata detection is heuristic-based, not negotiated through an explicit issuer version field
+
+## Rejected alternatives
+
+### One API shape for both specs
+
+Rejected because:
+
+- proof callback contract changed materially
+- response model changed materially
+- a shared public contract would either hide protocol differences or fabricate fields
+
+### Two totally separate end-to-end stacks
+
+Rejected because:
+
+- it would duplicate orchestration logic
+- cleanup later would be harder
+- most differences are at protocol edges, not the entire flow
+
+### Make Draft-13 the primary internal naming
+
+Rejected because:
+
+- the target architecture is OpenID4VCI 1.0
+- cleanup becomes harder if the compatibility path remains the default mental model
+
+## Migration and cleanup path
+
+Current intended end state:
+
+1. keep the public API surface aligned to OpenID4VCI 1.0
+2. keep Draft-13 behavior behind explicit `Draft13` methods
+3. retain response normalization only while Draft-13 support is needed
+4. when Draft-13 support is no longer needed:
+   - remove `Draft13` methods
+   - remove normalization logic
+
+## Implementation notes
+
+Primary files involved:
+
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/VCIClient.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credentialOffer/CredentialOfferFlowHandler.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/trustedIssuer/TrustedIssuerFlowHandler.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationCodeFlowService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/preAuthCodeFlow/PreAuthCodeFlowService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/CredentialRequestFactory.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/CredentialRequestFactoryDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/LdpVcCredentialRequestDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/JwtVcCredentialRequestDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/MsoMdocCredentialRequestDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/request/types/SdJwtCredentialRequestDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/response/CredentialResponse.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/credential/response/CredentialResponseDraft13.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/proof/CredentialRequestProofs.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/CallbackTypes.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/issuerMetadata/IssuerMetadataService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/nonce/NonceService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/constants/OID4VCIVersion.kt`

--- a/docs/adr/0001-openid4vci-v1-migration.md
+++ b/docs/adr/0001-openid4vci-v1-migration.md
@@ -37,7 +37,6 @@ Supporting public types:
 
 - `CredentialRequestProofs`
 - `CredentialResponse`
-- `CredentialResponseDraft13`
 - `OID4VCIVersion`
 
 Removed from the public surface (1.0.0):
@@ -73,7 +72,8 @@ public typealias ProofsCallback = suspend (
 
 Current `CredentialRequestProofs` supports:
 
-- `jwt: List<String>?`
+- proofType: `jwt`
+- proofs: `List<String>`
 
 This is intentionally plural at the wire boundary even though the current Draft-13 bridge still extracts the first JWT when talking to an older issuer.
 

--- a/docs/adr/0002-support-pdi-with-vp-request-v1.md
+++ b/docs/adr/0002-support-pdi-with-vp-request-v1.md
@@ -1,0 +1,136 @@
+# ADR-0002: Support for PDI with VP Request following OpenID4VP 1.0
+
+- Status: Accepted
+- Date: 2026-06-07
+
+## Context
+
+The OpenID4VP library (OVP) version 0.7.0 currently supports Verifiable Presentation (VP) Draft 23 specification.
+
+The VCI Client's Presentation During Issuance (PDI) authorization method must support both:
+
+- **VP 1.0**: Present-day Verifiable Presentation specification (primary path)
+- **Draft 23**: Legacy Verifiable Presentation Draft 23 specification (compatibility path)
+
+The main constraints are:
+
+* VP 1.0 and Draft 23 presentation requests provided by issuers must be supported transparently within PDI flows.
+* The core presentation behavior during the issuance flow must remain unchanged.
+
+## Decision
+
+Upgrade OVP library from version 0.7.0 to 1.0.0 and implement version-aware PDI flow handling to support both VP 1.0 and Draft 23 based requests, similar to the OpenID4VCI 1.0/Draft-13 pattern used for credential download flows.
+
+## Implementation Details
+
+To provide support for both VP requests following VP 1.0 and Draft 23 specification, the Inji OpenID4VP library needs to be updated to the latest version
+
+### OVP Library Upgrade (0.7.0 → 1.0.0)
+
+The OVP library version 1.0.0 introduces breaking changes to the Presentation During Issuance authorization method. These changes require updates to the `presentationDuringIssuance` authorization method in `AuthorizationMethod`.
+
+#### Public API Changes
+
+##### 1. Removal of `ldpVpSignatureSuite`
+
+- `ldpVpSignatureSuite` parameter has been removed from the public API
+- OVP 1.0.0 uses `JsonWebSignatureSuite2020` as the default signature suite for verifiable presentations
+- Linked Data Proof (LDP) signature suite input is no longer supported for `ldp_vp` presentations
+- The `presentationDuringIssuance` method now uses `JsonWebSignatureSuite2020` exclusively for verifiable presentations
+
+##### 2. `SelectCredentialsForPresentationCallback` Signature Change
+
+The callback for selecting credentials has been updated:
+
+| Aspect      | OVP 0.7.0                                                | OVP 1.0.0                                                  | Notes                                                                                                           |
+|-------------|----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| Output type | `Map<String, Map<FormatType, AnyCodable>>`               | `Map<String, Array<Credential>>`                           | Changed from format-grouped structure to credential array indexed by input descriptor ID or credential query ID |
+| Semantic    | Map of input descriptor ID to format-grouped credentials | Map of input descriptor ID to list of selected credentials | Simpler structure for credential selection                                                                      |
+
+##### 3. `SignVerifiablePresentationCallback` Signature Change
+
+Callback for signing verifiable presentations has been updated:
+
+| Aspect      | OVP 0.7.0                       | OVP 1.0.0                     | Notes                                                                                                                                                                  |
+|-------------|---------------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Input type  | `Array<UnsignedVPTokenV2>`      | `Array<UnsignedVPToken>`      | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation. |
+| Output type | `Array<VPTokenSigningResultV2>` | `Array<VPTokenSigningResult>` | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation. |
+
+
+- New canonicalization input parameter for JSON-LD data processing
+- **Required** when presenting credentials of format `ldp_vc`
+- Optional for other credential formats
+- Allows Kotlin consumers to provide custom JSON-LD canonicalization logic
+
+##### 5. Optional `openid4vpWalletConfig`
+
+* Introduces a new optional parameter for wallet-specific OpenID4VP configuration.
+* This configuration will be passed to the Inji OpenID4VP library, where it is used to control the wallet's behavior during OpenID4VP transactions and to customize the wallet metadata communicated to the verifier.
+
+#### Internal Changes
+
+##### 1. Removal of Holder ID Extraction Logic
+
+- OVP 1.0.0 removes holder ID as an input parameter from consumer code
+- Holder ID extraction is now handled internally by the OVP library
+- The OVP library automatically extracts holder ID from the verifiable credential
+- Holder binding proof generation for `ldp_vp` presentations is managed by the OVP library
+- Inji VCI Client no longer needs to extract or provide holder ID for `ldp_vp` presentations
+
+##### 2. Method Naming Changes
+
+The following internal method names have been updated to align with OVP 1.0.0:
+
+- `constructUnsignedVPTokenV2()` → `constructUnsignedVPToken()`
+- `constructVPResponseV2()` → `constructVPResponse()`
+
+These methods are used internally for:
+- Constructing the data structure to be signed for verifiable presentation creation
+- Building the final VP response object
+
+### Dual VP Specification Support
+
+The OVP library version 1.0.0 introduces support for Verifiable Presentation 1.0 specification alongside Draft 23 compatibility. The VCI Client implements version-aware PDI flow handling to support both specifications:
+
+- **VP 1.0**: Present-day Verifiable Presentation specification (primary path)
+- **Draft 23**: Legacy Verifiable Presentation Draft 23 specification (compatibility path)
+
+Version detection and routing are handled automatically by the OVP library, similar to the OpenID4VCI 1.0/Draft-13 pattern used for credential download flows. Version routing is transparent to consumers of the public API.
+
+## Consequences
+
+### Positive
+
+- Dual specification support (VP 1.0 and Draft 23) enables interoperability with both old and new issuers
+- Version detection and routing are handled internally by the OVP library, keeping version complexity hidden from consumers
+- Core presentation during issuance flow remains intact; only method contracts have changed
+- Similar pattern to OpenID4VCI 1.0/Draft-13 dual support provides consistency across the codebase
+- Holder ID management is simplified; the OVP library handles extraction internally
+- Cleaner callback signatures with simplified type naming (removal of V2 suffix)
+
+### Negative
+
+- Public API of `presentationDuringIssuance` has breaking changes that require code updates
+- Callback type signatures have changed, affecting integration code
+- Migration effort required for existing integrators
+
+## Migration Path
+
+### For integrators using PDI:
+
+1. Update all calls to `presentationDuringIssuance` to use new callback signatures
+2. Remove any `ldpVpSignatureSuite` parameter passing
+3. Update callback implementations:
+   - `SelectCredentialsForPresentationCallback`: Return `Map<String, Array<Credential>>` instead of format-grouped map
+   - `SignVerifiablePresentationCallback`: Accept `Array<UnsignedVPToken>` and return `Array<VPTokenSigningResult>` (without V2 suffix)
+5. Optionally provide wallet's OpenID4VP related configuration via `openid4vpWalletConfig`
+
+## Implementation Notes
+
+Primary files involved in PDI and OVP 1.0.0 support:
+
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceRequestData.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.kt`

--- a/docs/adr/0002-support-pdi-with-vp-request-v1.md
+++ b/docs/adr/0002-support-pdi-with-vp-request-v1.md
@@ -44,7 +44,7 @@ The callback for selecting credentials has been updated:
 
 | Aspect      | OVP 0.7.0                                                | OVP 1.0.0                                                  | Notes                                                                                                           |
 |-------------|----------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| Output type | `Map<String, Map<FormatType, AnyCodable>>`               | `Map<String, Array<Credential>>`                           | Changed from format-grouped structure to credential array indexed by input descriptor ID or credential query ID |
+| Output type | `Map<String, Map<FormatType, Any>>`                      | `Map<String, List<Credential>>`                            | Changed from format-grouped structure to credential list indexed by input descriptor ID or credential query ID  |
 | Semantic    | Map of input descriptor ID to format-grouped credentials | Map of input descriptor ID to list of selected credentials | Simpler structure for credential selection                                                                      |
 
 ##### 3. `SignVerifiablePresentationCallback` Signature Change
@@ -53,16 +53,11 @@ Callback for signing verifiable presentations has been updated:
 
 | Aspect      | OVP 0.7.0                       | OVP 1.0.0                     | Notes                                                                                                                                                                  |
 |-------------|---------------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Input type  | `Array<UnsignedVPTokenV2>`      | `Array<UnsignedVPToken>`      | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation. |
-| Output type | `Array<VPTokenSigningResultV2>` | `Array<VPTokenSigningResult>` | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation. |
+| Input type  | `List<UnsignedVPTokenV2>`       | `List<UnsignedVPToken>`       | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation.  |
+| Output type | `List<VPTokenSigningResultV2>`  | `List<VPTokenSigningResult>`  | Versioning simplified by removing V2 suffix. New version includes an `id` field to link unsigned VP tokens with their corresponding signed results during preparation.  |
 
 
-- New canonicalization input parameter for JSON-LD data processing
-- **Required** when presenting credentials of format `ldp_vc`
-- Optional for other credential formats
-- Allows Kotlin consumers to provide custom JSON-LD canonicalization logic
-
-##### 5. Optional `openid4vpWalletConfig`
+##### 4. Optional `openid4vpWalletConfig`
 
 * Introduces a new optional parameter for wallet-specific OpenID4VP configuration.
 * This configuration will be passed to the Inji OpenID4VP library, where it is used to control the wallet's behavior during OpenID4VP transactions and to customize the wallet metadata communicated to the verifier.
@@ -121,16 +116,15 @@ Version detection and routing are handled automatically by the OVP library, simi
 1. Update all calls to `presentationDuringIssuance` to use new callback signatures
 2. Remove any `ldpVpSignatureSuite` parameter passing
 3. Update callback implementations:
-   - `SelectCredentialsForPresentationCallback`: Return `Map<String, Array<Credential>>` instead of format-grouped map
-   - `SignVerifiablePresentationCallback`: Accept `Array<UnsignedVPToken>` and return `Array<VPTokenSigningResult>` (without V2 suffix)
-5. Optionally provide wallet's OpenID4VP related configuration via `openid4vpWalletConfig`
+   - `SelectCredentialsForPresentationCallback`: Return `Map<String, List<Credential>>` instead of format-grouped map
+   - `SignVerifiablePresentationCallback`: Accept `List<UnsignedVPToken>` and return `List<VPTokenSigningResult>` (without V2 suffix)
+4. Optionally provide wallet's OpenID4VP related configuration via `openid4vpWalletConfig`
 
 ## Implementation Notes
 
 Primary files involved in PDI and OVP 1.0.0 support:
 
 - `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/AuthorizationMethod.kt`
-- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt`
-- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceRequestData.kt`
-- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.kt`
-- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationDuringIssuanceRequestData.kt`
+- `kotlin/vci-client/src/main/java/io/mosip/vciclient/authorizationCodeFlow/interactiveAuthorization/presentationDuringIssuance/PresentationInteractionResponse.kt`

--- a/docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md
+++ b/docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md
@@ -12,59 +12,56 @@ Note:
 ## Quick flow overview
 
 1. `VCIClient(traceabilityId)` initialises the client for the session.
-2. `getIssuerMetadata(credentialIssuer =)` fetches issuer well-known metadata.
-3. `getCredentialConfigurationsSupported(credentialIssuer =)` fetches supported credential configurations.
+2. `getIssuerMetadata(credentialIssuer = ...)` fetches issuer well-known metadata.
+3. `getCredentialConfigurationsSupported(credentialIssuer = ...)` fetches supported credential configurations.
 4. `fetchCredentialsUsingCredentialOffer(...)` (issuer-initiated) or `fetchCredentialsFromTrustedIssuer(...)` (wallet-initiated) downloads credentials and returns a `CredentialResponse`.
-5. Your wallet reads `credentialResponse.credentials` — a `List<CredentialItem>` list — and renders each item.
+5. Your wallet reads `credentialResponse.credentials?.orEmpty()` — a `List<CredentialItem>?` list — and renders each item.
 
 ---
 
 ## Feature overview
 
 1. **0.7.0**
-   1. Supported OID4VCI draft 13.
-   2. Credential download methods returned a single `credential: AnyCodable`.
-   3. Proof callback accepted one nonce and returned a single JWT string.
+    1. Supported OID4VCI draft 13.
+    2. Credential download methods returned a single `credential: JsonElement?`.
+    3. Proof callback accepted one nonce and returned a single JWT string.
 
 2. **1.0.0**
-   1. Supports OID4VCI **1.0** with retained draft 13 backward compatibility — the library auto-detects the issuer's spec version from its metadata.
-   2. Credential download methods return a `credentials: List<CredentialItem>` list, matching the OID4VCI 1.0 response shape.
-   3. Proof callback returns a `CredentialRequestProofs` object, supporting one or more proofs per request.
-   4. **PDI `selectCredentialsForPresentation` callback** now returns `Map<String, List<Credential>>` instead of `Map<String, Map<FormatType, Any>>`.
-   5. **PDI `signVerifiablePresentation` callback** now returns `List<VPTokenSigningResult>` instead of `List<VPTokenSigningResultV2>`.
-   7. **PDI response modes updated**: `iar_post` / `iar_post.jwt` are the supported response modes.
-   8. Issuer metadata fetch now validates that `credential_issuer` in the well-known response matches the requested issuer [OID4VCI §12.2.4](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4-2.1).
-   9. `VCIClientException` carries structured upstream error fields (`issuerErrorCode`, `issuerErrorDescription`).
-   10. Legacy low-level APIs (`requestCredential`, `requestCredentialByCredentialOffer`, `requestCredentialFromTrustedIssuer`) have been removed.
+    1. Supports OID4VCI **1.0** with retained draft 13 backward compatibility — the library auto-detects the issuer's spec version from its metadata.
+    2. Credential download methods return a `credentials: List<CredentialItem>?` list, matching the OID4VCI 1.0 response shape.
+    3. Proof callback returns a `CredentialRequestProofs` object, supporting one or more proofs per request.
+    4. **PDI `selectCredentialsForPresentation` callback** now returns `Map<String, List<Credential>>` instead of `Map<String, Map<FormatType, Any>>`.
+    5. **PDI `signVerifiablePresentation` callback** now returns `List<VPTokenSigningResult>` instead of `List<VPTokenSigningResultV2>`.
+    6. Issuer metadata fetch now validates that `credential_issuer` in the well-known response matches the requested issuer [OID4VCI §12.2.4](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4-2.1).
+    7. `VCIClientException` carries structured upstream error fields (`issuerErrorCode`, `issuerErrorDescription`).
+    8. Legacy low-level APIs (`requestCredential`, `requestCredentialByCredentialOffer`, `requestCredentialFromTrustedIssuer`) have been removed.
 
 ---
 
 ## TL;DR (what you must change)
 
 1. **Rename credential offer method**
-   - **0.7.0**: `fetchCredentialUsingCredentialOffer(...)`
-   - **1.0.0**: `fetchCredentialsUsingCredentialOffer(...)` (plural *Credentials*)
+    - **0.7.0**: `fetchCredentialUsingCredentialOffer(...)`
+    - **1.0.0**: `fetchCredentialsUsingCredentialOffer(...)` (plural *Credentials*)
 
 2. **Rename trusted issuer method**
-   - **0.7.0**: `fetchCredentialFromTrustedIssuer(...)`
-   - **1.0.0**: `fetchCredentialsFromTrustedIssuer(...)` (plural *Credentials*)
+    - **0.7.0**: `fetchCredentialFromTrustedIssuer(...)`
+    - **1.0.0**: `fetchCredentialsFromTrustedIssuer(...)` (plural *Credentials*)
 
 3. **Replace `getProofJwt` callback with `getProofs`**
-   - **0.7.0**: `getProofJwt = (credentialIssuer, cNonce, proofSigningAlgorithmsSupported) -> String`
-   - **1.0.0**: `getProofs = (credentialIssuer, nonce, proofSigningAlgorithmsSupported) -> CredentialRequestProofs`
+    - **0.7.0**: `getProofJwt = (credentialIssuer, cNonce, proofSigningAlgorithmsSupported) -> String`
+    - **1.0.0**: `getProofs = (credentialIssuer, nonce, proofSigningAlgorithmsSupported) -> CredentialRequestProofs`
 
 4. **Update credential response access**
-   - **0.7.0**: `credentialResponse?.credential` (`AnyCodable`)
-   - **1.0.0**: `credentialResponse.credentials` (`List<CredentialItem>`); access each via `item.credential`
+    - **0.7.0**: `credentialResponse?.credential` (`JsonElement?`)
+    - **1.0.0**: `credentialResponse.credentials?.orEmpty()` (`List<CredentialItem>?`); access each via `item.credential`
 
 5. **Update PDI callbacks** — `selectCredentialsForPresentation` now returns `Map<String, List<Credential>>` (not `Map<String, Map<FormatType, Any>>`); `signVerifiablePresentation` now returns `List<VPTokenSigningResult>` (not `List<VPTokenSigningResultV2>`).
 
 
-7. **Update PDI response mode handling** — use `iar_post` / `iar_post.jwt` response modes.
+6. **Remove any calls to deleted APIs** — `requestCredential`, `requestCredentialByCredentialOffer`, and `requestCredentialFromTrustedIssuer` are gone; migrate to the `fetchCredentials*` methods.
 
-8. **Remove any calls to deleted APIs** — `requestCredential`, `requestCredentialByCredentialOffer`, and `requestCredentialFromTrustedIssuer` are gone; migrate to the `fetchCredentials*` methods.
-
-9. **Update error handling** — `VCIClientException` now exposes `issuerErrorCode` and `issuerErrorDescription` alongside `code` and `message`.
+7. **Update error handling** — `VCIClientException` now exposes `issuerErrorCode` and `issuerErrorDescription` alongside `code` and `message`.
 
 ---
 
@@ -78,11 +75,11 @@ val credentialResponse: CredentialResponse? = vciClient.fetchCredentialUsingCred
     clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
     getTxCode = { inputMode, description, length -> "sampleTxCode"
     },
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
-            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            selectCredentialsForPresentation = { vpRequest -> selectCredentialsForPresentationCallback(vpRequest = vpRequest)
             },
-            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            signVerifiablePresentation = { unsignedVPTokens -> signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
             },
             ldpVpSignatureSuite = "Ed25519Signature2020"
         ),
@@ -98,9 +95,9 @@ val credentialResponse: CredentialResponse? = vciClient.fetchCredentialUsingCred
     downloadTimeoutInMillis = 10_000
 )
 
-credentialResponse?.credential           // AnyCodable — the single downloaded credential
-credentialResponse?.credentialConfigurationId
-credentialResponse?.credentialIssuer
+credentialResponse?.credential           // JsonElement? — the single downloaded credential
+credentialResponse?.credentialConfigurationId // String?
+credentialResponse?.credentialIssuer // String?
 ```
 
 ### 1.0.0 (new)
@@ -111,11 +108,11 @@ val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
     clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
     getTxCode = { inputMode, description, length -> "sampleTxCode"
     },
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
-            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            selectCredentialsForPresentation = { vpRequest -> selectCredentialsForPresentationCallback(vpRequest = vpRequest)
             },
-            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            signVerifiablePresentation = { unsignedVPTokens -> signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
             }
         ),
         AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
@@ -130,26 +127,26 @@ val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
     downloadTimeoutInMillis = 10_000
 )
 
-credentialResponse.credentials            // List<CredentialItem> — list of downloaded credentials
-credentialResponse.credentials.firstOrNull()?.credential  // AnyCodable of the first credential
-credentialResponse.credentialConfigurationId
-credentialResponse.credentialIssuer
+credentialResponse.credentials?.orEmpty() // List<CredentialItem>? — list of downloaded credentials
+credentialResponse.credentials?.firstOrNull()?.credential?.asJsonObject  // JsonElement? of the first credential
+credentialResponse.credentialConfigurationId // String?
+credentialResponse.credentialIssuer // String?
 ```
 
 ### Parameter mapping
 
-| 0.7.0 parameter                                                                                                                               | 1.0.0 parameter             | Migration note                                                                |
-|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
-| `getProofJwt = ProofJwtCallback`                                                                                                               | `getProofs = ProofsCallback` | Return a `CredentialRequestProofs(proofs = listOf(...])` instead of a plain `String` |
-| `credentialOffer`, `clientMetadata`, `getTxCode`, `authorizationMethods`, `getTokenResponse`, `onCheckIssuerTrust`, `downloadTimeoutInMillis` | _(unchanged)_               | Same parameter names and types                                                |
+| 0.7.0 parameter | 1.0.0 parameter | Migration note |
+| --- | --- | --- |
+| `getProofJwt = ProofJwtCallback` | `getProofs = ProofsCallback` | Return a `CredentialRequestProofs(proofs = listOf(...))` instead of a plain `String` |
+| `credentialOffer`, `clientMetadata`, `getTxCode`, `authorizationMethods`, `getTokenResponse`, `onCheckIssuerTrust`, `downloadTimeoutInMillis` | *(unchanged)* | Same parameter names and types |
 
 ### Response mapping
 
-| 0.7.0 field                          | 1.0.0 field                         | Migration note                                                                |
-|--------------------------------------|-------------------------------------|-------------------------------------------------------------------------------|
-| `credential: AnyCodable`             | `credentials: List<CredentialItem>`     | Iterate `credentials`; each `CredentialItem` exposes `credential: AnyCodable` |
-| `credentialConfigurationId = String?` | `credentialConfigurationId = String` | No longer optional                                                            |
-| `credentialIssuer = String?`          | `credentialIssuer = String`          | No longer optional                                                            |
+| 0.7.0 field | 1.0.0 field | Migration note |
+| --- | --- | --- |
+| `credential: JsonElement?` | `credentials: List<CredentialItem>?` | Iterate `credentials?.orEmpty()`; each `CredentialItem` exposes `credential: JsonElement?`. Use schema-based deserialization for typed fields. |
+| `credentialConfigurationId = String?` | `credentialConfigurationId = String?` | Still nullable                                                            |
+| `credentialIssuer = String?`          | `credentialIssuer = String?`          | Still nullable                                                            |
 
 ---
 
@@ -162,11 +159,11 @@ val credentialResponse: CredentialResponse? = vciClient.fetchCredentialFromTrust
     credentialIssuer = "https://sample-issuer.com",
     credentialConfigurationId = "DriversLicense",
     clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
-            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            selectCredentialsForPresentation = { vpRequest -> selectCredentialsForPresentationCallback(vpRequest = vpRequest)
             },
-            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            signVerifiablePresentation = { unsignedVPTokens -> signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
             },
             ldpVpSignatureSuite = "Ed25519Signature2020"
         ),
@@ -192,11 +189,11 @@ val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
     credentialIssuer = "https://sample-issuer.com",
     credentialConfigurationId = "DriversLicense",
     clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
-            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            selectCredentialsForPresentation = { vpRequest -> selectCredentialsForPresentationCallback(vpRequest = vpRequest)
             },
-            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            signVerifiablePresentation = { unsignedVPTokens -> signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
             }
         ),
         AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
@@ -209,9 +206,9 @@ val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
     downloadTimeoutInMillis = 10_000
 )
 
-credentialResponse.credentials
-credentialResponse.credentialConfigurationId
-credentialResponse.credentialIssuer
+credentialResponse.credentials?.orEmpty()
+credentialResponse.credentialConfigurationId // String?
+credentialResponse.credentialIssuer // String?
 ```
 
 The parameter and response mapping is the same as described in the credential offer section above.
@@ -228,21 +225,21 @@ The parameter and response mapping is the same as described in the credential of
 ### What changes in practice
 
 1. **`selectCredentialsForPresentation` return type changed**
-   - **0.7.0**: returned `Map<String, Map<FormatType, Any>>`
-   - **1.0.0**: returns `Map<String, List<Credential>>` — a flat list of `Credential` objects per input descriptor ID /Credential query ID
+    - **0.7.0**: returned `Map<String, Map<FormatType, Any>>`
+    - **1.0.0**: returns `Map<String, List<Credential>>` — a flat list of `Credential` objects per input descriptor ID /Credential query ID
 
 2. **`signVerifiablePresentation` callback inputs and return changed**
-   - **0.7.0**: Input: `List<UnsignedVPTokenV2>`
-   - **1.0.0**: Input: `List<UnsignedVPToken>` (adds the `id` property in addition to `format`, `holderKeyReference`, `signatureAlgorithm`, and `dataToSign`)
+    - **0.7.0**: Input: `List<UnsignedVPTokenV2>`
+    - **1.0.0**: Input: `List<UnsignedVPToken>` (adds the `id` property in addition to `format`, `holderKeyReference`, `signatureAlgorithm`, and `dataToSign`)
 
-   - **0.7.0**: Returns: `List<VPTokenSigningResultV2>`
-   - **1.0.0**: Returns: `List<VPTokenSigningResult>` (adds the `id` property in addition to `signedData`)
+    - **0.7.0**: Returns: `List<VPTokenSigningResultV2>`
+    - **1.0.0**: Returns: `List<VPTokenSigningResult>` (adds the `id` property in addition to `signedData`)
 
-3. **Two new PDI parameters added**
-   - `openid4vpWalletConfig` — optional OpenID4VP wallet configuration (trusted verifiers, supported formats, etc.)
+3. **New PDI parameter added**
+    - `openid4vpWalletConfig` — optional OpenID4VP wallet configuration (trusted verifiers, supported formats, etc.)
 
 4. **Response modes updated**
-   - `iar_post` and `iar_post.jwt` are the supported response modes in 1.0.0
+    - `iar_post` and `iar_post.jwt` are the supported response modes in 1.0.0
 
 ### 0.7.0 PDI usage (old)
 
@@ -264,9 +261,6 @@ AuthorizationMethod.presentationDuringIssuance(
 
 ```kotlin
 AuthorizationMethod.presentationDuringIssuance(
-        // Required only for ldp_vc — canonicalize JSON-LD and return base64url-encoded hash
-        return canonicalizeAndHash(data)
-    },
     openid4vpWalletConfig = WalletConfig(), // Optional — use defaults or pass your config
     selectCredentialsForPresentation = { presentationRequest -> // 1.0.0: return Map<String, List<Credential>> — flat list per descriptor/query ID
         val selectedCredentials: Map<String, List<Credential>> = selectCredentials(presentationRequest)
@@ -281,12 +275,12 @@ AuthorizationMethod.presentationDuringIssuance(
 
 ### Parameter mapping
 
-| 0.7.0 parameter                    | 1.0.0 parameter                    | Change                                                                          |
-|------------------------------------|------------------------------------|---------------------------------------------------------------------------------|
-| _(not present)_                    | `openid4vpWalletConfig`            | **New** — optional OpenID4VP wallet config                                      |
+| 0.7.0 parameter | 1.0.0 parameter | Change |
+| --- | --- | --- |
+| *(not present)* | `openid4vpWalletConfig` | **New** — optional OpenID4VP wallet config |
 | `selectCredentialsForPresentation` | `selectCredentialsForPresentation` | Return type changed: `Map<String, Map<FormatType, Any>>` → `Map<String, List<Credential>>` |
-| `signVerifiablePresentation`       | `signVerifiablePresentation`       | Return type changed: `List<VPTokenSigningResultV2>` → `List<VPTokenSigningResult>`      |
-| `ldpVpSignatureSuite`              | (not present)                      | Removed                                                                         |
+| `signVerifiablePresentation` | `signVerifiablePresentation` | Return type changed: `List<VPTokenSigningResultV2>` → `List<VPTokenSigningResult>` |
+| `ldpVpSignatureSuite` | (not present) | Removed |
 
 ---
 
@@ -301,10 +295,10 @@ AuthorizationMethod.presentationDuringIssuance(
 
 Two structured fields are now available on `VCIClientException`:
 
-| New field                | Type      | Meaning                                                                                                        |
-|--------------------------|-----------|----------------------------------------------------------------------------------------------------------------|
-| `issuerErrorCode`        | `String?` | The `error` value returned by the issuer or authorization server in a structured OAuth/OID4VCI error response. |
-| `issuerErrorDescription` | `String?` | The `error_description` from the upstream server, or the raw body when structured parsing is not possible.     |
+| New field | Type | Meaning |
+| --- | --- | --- |
+| `issuerErrorCode` | `String?` | The `error` value returned by the issuer or authorization server in a structured OAuth/OID4VCI error response. |
+| `issuerErrorDescription` | `String?` | The `error_description` from the upstream server, or the raw body when structured parsing is not possible. |
 
 Additionally, `code` now resolves to the **root** error code across the cause chain — if an exception wraps another `VCIClientException`, `code` carries the deepest `VCI-*` code rather than the wrapper's own code.
 
@@ -353,31 +347,31 @@ try {
 
 ### API changes
 
-| 0.7.0                                                                    | 1.0.0 status      | Change                                                                                                                                        |
-|--------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `fetchCredentialUsingCredentialOffer(...)`                               | **Renamed**       | Use `fetchCredentialsUsingCredentialOffer(...)`                                                                                               |
-| `fetchCredentialFromTrustedIssuer(...)`                                  | **Renamed**       | Use `fetchCredentialsFromTrustedIssuer(...)`                                                                                                  |
-| `getProofJwt` callback                                                   | **Replaced**      | Use `getProofs` returning `CredentialRequestProofs`                                                                                           |
-| `CredentialResponse.credential: AnyCodable`                              | **Replaced**      | Use `CredentialResponse.credentials: List<CredentialItem>`                                                                                        |
-| PDI `selectCredentialsForPresentation` → `Map<String, Map<FormatType, Any>>` | **Changed**       | Now returns `Map<String, List<Credential>>`                                                                                                          |
-| PDI `signVerifiablePresentation`                                         | **Changed**       | Input changed from `UnsignedVPTokenV2` to `UnsignedVPToken`. Return type changed from `List<VPTokenSigningResultV2>` to `List<VPTokenSigningResult>`. |
-| PDI _(no `openid4vpWalletConfig`)_                                       | **New parameter** | Optional OpenID4VP wallet configuration                                                                                                       |
+| 0.7.0 | 1.0.0 status | Change |
+| --- | --- | --- |
+| `fetchCredentialUsingCredentialOffer(...)` | **Renamed** | Use `fetchCredentialsUsingCredentialOffer(...)` |
+| `fetchCredentialFromTrustedIssuer(...)` | **Renamed** | Use `fetchCredentialsFromTrustedIssuer(...)` |
+| `getProofJwt` callback | **Replaced** | Use `getProofs` returning `CredentialRequestProofs` |
+| `CredentialResponse.credential: JsonElement?` | **Replaced** | Use `CredentialResponse.credentials: List<CredentialItem>?` |
+| PDI `selectCredentialsForPresentation` → `Map<String, Map<FormatType, Any>>` | **Changed** | Now returns `Map<String, List<Credential>>` |
+| PDI `signVerifiablePresentation` | **Changed** | Input changed from `UnsignedVPTokenV2` to `UnsignedVPToken`. Return type changed from `List<VPTokenSigningResultV2>` to `List<VPTokenSigningResult>`. |
+| PDI *(no `openid4vpWalletConfig`)* | **New parameter** | Optional OpenID4VP wallet configuration |
 
 ### APIs removed in 1.0.0
 
-| Removed method                            | Deprecated since | Replacement                                                                             |
-|-------------------------------------------|------------------|-----------------------------------------------------------------------------------------|
-| `requestCredentialByCredentialOffer(...)` | 0.7.0            | `fetchCredentialsUsingCredentialOffer(...)`                                             |
-| `requestCredentialFromTrustedIssuer(...)` | 0.7.0            | `fetchCredentialsFromTrustedIssuer(...)`                                                |
-| `requestCredential(...)`                  | 0.7.0            | `fetchCredentialsUsingCredentialOffer(...)` or `fetchCredentialsFromTrustedIssuer(...)` |
+| Removed method | Deprecated since | Replacement |
+| --- | --- | --- |
+| `requestCredentialByCredentialOffer(...)` | 0.7.0 | `fetchCredentialsUsingCredentialOffer(...)` |
+| `requestCredentialFromTrustedIssuer(...)` | 0.7.0 | `fetchCredentialsFromTrustedIssuer(...)` |
+| `requestCredential(...)` | 0.7.0 | `fetchCredentialsUsingCredentialOffer(...)` or `fetchCredentialsFromTrustedIssuer(...)` |
 
 ### Unchanged APIs
 
 The following public methods are unchanged in 1.0.0:
 
 - `VCIClient(traceabilityId)`
-- `getIssuerMetadata(credentialIssuer =)`
-- `getCredentialConfigurationsSupported(credentialIssuer =)`
+- `getIssuerMetadata(credentialIssuer = ...)`
+- `getCredentialConfigurationsSupported(credentialIssuer = ...)`
 
 ---
 
@@ -401,7 +395,7 @@ fun downloadCredential(
         getTxCode = { inputMode, description, length -> // Prompt user for transaction code if required
             return "userProvidedTxCode"
         },
-        authorizationMethods = listOf(
+        authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
                 selectCredentialsForPresentation = { presentationRequest -> // Return wallet credentials matching the presentation request
                     emptyMap()
@@ -425,7 +419,7 @@ fun downloadCredential(
         },
         getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> // Build and sign proof JWT(s) using nonce and supported algorithms
             val signedProofJwt = buildAndSignProofJwt(nonce = nonce, issuer = credentialIssuer)
-            return CredentialRequestProofs(proofs = listOf(signedProofJwt))
+           CredentialRequestProofs(proofs = listOf(signedProofJwt))
         },
         onCheckIssuerTrust = { credentialIssuer, issuerDisplay -> // Return true if the issuer is trusted by the wallet
             return true
@@ -433,8 +427,8 @@ fun downloadCredential(
         downloadTimeoutInMillis = 10_000
     )
 
-    // credentialResponse.credentials is List<CredentialItem>
-    return credentialResponse.credentials
+    // credentialResponse.credentials is List<CredentialItem>?
+    return credentialResponse.credentials?.orEmpty()
 }
 
 // Helpers (implement in your wallet app)
@@ -447,8 +441,9 @@ fun buildAndSignProofJwt(nonce: String, issuer: String): String {
 
 Notes:
 - Replace stub callback bodies with your wallet's actual implementation.
-- `getProofs` replaces the old `getProofJwt` — wrap your signed JWT in `CredentialRequestProofs(proofs = listOf(...])`.
-- Iterate `credentialResponse.credentials` to access each downloaded credential via `.credential` (`AnyCodable`).
+- `getProofs` replaces the old `getProofJwt` — wrap your signed JWT in `CredentialRequestProofs(proofs = listOf(...))`.
+- Iterate `credentialResponse.credentials?.orEmpty()` to access each downloaded credential via `.credential` (`JsonElement?`).
+- Use schema-based deserialization to map `JsonElement` into typed fields instead of direct casting.
 
 ---
 

--- a/docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md
+++ b/docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md
@@ -1,0 +1,468 @@
+# Migration Guide: inji-vci-client 0.7.0 → 1.0.0
+
+This guide helps Kotlin developers upgrade from **`inji-vci-client` 0.7.0** to **1.0.0**.
+
+Scope: **breaking changes in the public API** — `VCIClient` class, its credential download methods, and the Presentation During Issuance (PDI) authorization callbacks.
+
+Note:
+- The core flow and concepts remain the same, but method names, the proof callback, the credential response model, and the PDI callback signatures have changed to align with the final OpenID4VCI 1.0 specification.
+
+---
+
+## Quick flow overview
+
+1. `VCIClient(traceabilityId)` initialises the client for the session.
+2. `getIssuerMetadata(credentialIssuer =)` fetches issuer well-known metadata.
+3. `getCredentialConfigurationsSupported(credentialIssuer =)` fetches supported credential configurations.
+4. `fetchCredentialsUsingCredentialOffer(...)` (issuer-initiated) or `fetchCredentialsFromTrustedIssuer(...)` (wallet-initiated) downloads credentials and returns a `CredentialResponse`.
+5. Your wallet reads `credentialResponse.credentials` — a `List<CredentialItem>` list — and renders each item.
+
+---
+
+## Feature overview
+
+1. **0.7.0**
+   1. Supported OID4VCI draft 13.
+   2. Credential download methods returned a single `credential: AnyCodable`.
+   3. Proof callback accepted one nonce and returned a single JWT string.
+
+2. **1.0.0**
+   1. Supports OID4VCI **1.0** with retained draft 13 backward compatibility — the library auto-detects the issuer's spec version from its metadata.
+   2. Credential download methods return a `credentials: List<CredentialItem>` list, matching the OID4VCI 1.0 response shape.
+   3. Proof callback returns a `CredentialRequestProofs` object, supporting one or more proofs per request.
+   4. **PDI `selectCredentialsForPresentation` callback** now returns `Map<String, List<Credential>>` instead of `Map<String, Map<FormatType, Any>>`.
+   5. **PDI `signVerifiablePresentation` callback** now returns `List<VPTokenSigningResult>` instead of `List<VPTokenSigningResultV2>`.
+   7. **PDI response modes updated**: `iar_post` / `iar_post.jwt` are the supported response modes.
+   8. Issuer metadata fetch now validates that `credential_issuer` in the well-known response matches the requested issuer [OID4VCI §12.2.4](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4-2.1).
+   9. `VCIClientException` carries structured upstream error fields (`issuerErrorCode`, `issuerErrorDescription`).
+   10. Legacy low-level APIs (`requestCredential`, `requestCredentialByCredentialOffer`, `requestCredentialFromTrustedIssuer`) have been removed.
+
+---
+
+## TL;DR (what you must change)
+
+1. **Rename credential offer method**
+   - **0.7.0**: `fetchCredentialUsingCredentialOffer(...)`
+   - **1.0.0**: `fetchCredentialsUsingCredentialOffer(...)` (plural *Credentials*)
+
+2. **Rename trusted issuer method**
+   - **0.7.0**: `fetchCredentialFromTrustedIssuer(...)`
+   - **1.0.0**: `fetchCredentialsFromTrustedIssuer(...)` (plural *Credentials*)
+
+3. **Replace `getProofJwt` callback with `getProofs`**
+   - **0.7.0**: `getProofJwt = (credentialIssuer, cNonce, proofSigningAlgorithmsSupported) -> String`
+   - **1.0.0**: `getProofs = (credentialIssuer, nonce, proofSigningAlgorithmsSupported) -> CredentialRequestProofs`
+
+4. **Update credential response access**
+   - **0.7.0**: `credentialResponse?.credential` (`AnyCodable`)
+   - **1.0.0**: `credentialResponse.credentials` (`List<CredentialItem>`); access each via `item.credential`
+
+5. **Update PDI callbacks** — `selectCredentialsForPresentation` now returns `Map<String, List<Credential>>` (not `Map<String, Map<FormatType, Any>>`); `signVerifiablePresentation` now returns `List<VPTokenSigningResult>` (not `List<VPTokenSigningResultV2>`).
+
+
+7. **Update PDI response mode handling** — use `iar_post` / `iar_post.jwt` response modes.
+
+8. **Remove any calls to deleted APIs** — `requestCredential`, `requestCredentialByCredentialOffer`, and `requestCredentialFromTrustedIssuer` are gone; migrate to the `fetchCredentials*` methods.
+
+9. **Update error handling** — `VCIClientException` now exposes `issuerErrorCode` and `issuerErrorDescription` alongside `code` and `message`.
+
+---
+
+## Before vs After: credential offer download
+
+### 0.7.0 (old)
+
+```kotlin
+val credentialResponse: CredentialResponse? = vciClient.fetchCredentialUsingCredentialOffer(
+    credentialOffer = "openid-credential-offer://?credential_offer_uri=...",
+    clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
+    getTxCode = { inputMode, description, length -> "sampleTxCode"
+    },
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            },
+            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            },
+            ldpVpSignatureSuite = "Ed25519Signature2020"
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(accessToken = "sampleAccessToken", cNonce = "sampleNonce",
+                      tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
+    },
+    getProofJwt = { credentialIssuer, cNonce, proofSigningAlgorithmsSupported -> // Sign JWT and return the compact serialization
+        "sampleProofJwt"
+    },
+    onCheckIssuerTrust = { credentialIssuer, issuerDisplay -> true },
+    downloadTimeoutInMillis = 10_000
+)
+
+credentialResponse?.credential           // AnyCodable — the single downloaded credential
+credentialResponse?.credentialConfigurationId
+credentialResponse?.credentialIssuer
+```
+
+### 1.0.0 (new)
+
+```kotlin
+val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
+    credentialOffer = "openid-credential-offer://?credential_offer_uri=...",
+    clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
+    getTxCode = { inputMode, description, length -> "sampleTxCode"
+    },
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            },
+            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            }
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(accessToken = "sampleAccessToken", cNonce = "sampleNonce",
+                      tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
+    },
+    getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> // Sign JWT(s) and wrap in CredentialRequestProofs
+        CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
+    },
+    onCheckIssuerTrust = { credentialIssuer, issuerDisplay -> true },
+    downloadTimeoutInMillis = 10_000
+)
+
+credentialResponse.credentials            // List<CredentialItem> — list of downloaded credentials
+credentialResponse.credentials.firstOrNull()?.credential  // AnyCodable of the first credential
+credentialResponse.credentialConfigurationId
+credentialResponse.credentialIssuer
+```
+
+### Parameter mapping
+
+| 0.7.0 parameter                                                                                                                               | 1.0.0 parameter             | Migration note                                                                |
+|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
+| `getProofJwt = ProofJwtCallback`                                                                                                               | `getProofs = ProofsCallback` | Return a `CredentialRequestProofs(proofs = listOf(...])` instead of a plain `String` |
+| `credentialOffer`, `clientMetadata`, `getTxCode`, `authorizationMethods`, `getTokenResponse`, `onCheckIssuerTrust`, `downloadTimeoutInMillis` | _(unchanged)_               | Same parameter names and types                                                |
+
+### Response mapping
+
+| 0.7.0 field                          | 1.0.0 field                         | Migration note                                                                |
+|--------------------------------------|-------------------------------------|-------------------------------------------------------------------------------|
+| `credential: AnyCodable`             | `credentials: List<CredentialItem>`     | Iterate `credentials`; each `CredentialItem` exposes `credential: AnyCodable` |
+| `credentialConfigurationId = String?` | `credentialConfigurationId = String` | No longer optional                                                            |
+| `credentialIssuer = String?`          | `credentialIssuer = String`          | No longer optional                                                            |
+
+---
+
+## Before vs After: trusted issuer download
+
+### 0.7.0 (old)
+
+```kotlin
+val credentialResponse: CredentialResponse? = vciClient.fetchCredentialFromTrustedIssuer(
+    credentialIssuer = "https://sample-issuer.com",
+    credentialConfigurationId = "DriversLicense",
+    clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            },
+            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            },
+            ldpVpSignatureSuite = "Ed25519Signature2020"
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(accessToken = "sampleAccessToken", cNonce = "sampleNonce",
+                      tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
+    },
+    getProofJwt = { credentialIssuer, cNonce, proofSigningAlgorithmsSupported -> "sampleProofJwt"
+    },
+    downloadTimeoutInMillis = 10_000
+)
+
+credentialResponse?.credential
+credentialResponse?.credentialConfigurationId
+credentialResponse?.credentialIssuer
+```
+
+### 1.0.0 (new)
+
+```kotlin
+val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
+    credentialIssuer = "https://sample-issuer.com",
+    credentialConfigurationId = "DriversLicense",
+    clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = { vpRequest -> try selectCredentialsForPresentationCallback(vpRequest: vpRequest)
+            },
+            signVerifiablePresentation = { unsignedVPTokens -> try signVerifiablePresentationCallback(unsignedVPTokens = unsignedVPTokens)
+            }
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(accessToken = "sampleAccessToken", cNonce = "sampleNonce",
+                      tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
+    },
+    getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
+    },
+    downloadTimeoutInMillis = 10_000
+)
+
+credentialResponse.credentials
+credentialResponse.credentialConfigurationId
+credentialResponse.credentialIssuer
+```
+
+The parameter and response mapping is the same as described in the credential offer section above.
+
+---
+
+## Before vs After: Presentation During Issuance (PDI) callbacks
+
+### What stays the same
+
+- `AuthorizationMethod.presentationDuringIssuance(...)` is still the way to pass PDI into both download methods.
+- `selectCredentialsForPresentation` and `signVerifiablePresentation` callbacks are still required.
+
+### What changes in practice
+
+1. **`selectCredentialsForPresentation` return type changed**
+   - **0.7.0**: returned `Map<String, Map<FormatType, Any>>`
+   - **1.0.0**: returns `Map<String, List<Credential>>` — a flat list of `Credential` objects per input descriptor ID /Credential query ID
+
+2. **`signVerifiablePresentation` callback inputs and return changed**
+   - **0.7.0**: Input: `List<UnsignedVPTokenV2>`
+   - **1.0.0**: Input: `List<UnsignedVPToken>` (adds the `id` property in addition to `format`, `holderKeyReference`, `signatureAlgorithm`, and `dataToSign`)
+
+   - **0.7.0**: Returns: `List<VPTokenSigningResultV2>`
+   - **1.0.0**: Returns: `List<VPTokenSigningResult>` (adds the `id` property in addition to `signedData`)
+
+3. **Two new PDI parameters added**
+   - `openid4vpWalletConfig` — optional OpenID4VP wallet configuration (trusted verifiers, supported formats, etc.)
+
+4. **Response modes updated**
+   - `iar_post` and `iar_post.jwt` are the supported response modes in 1.0.0
+
+### 0.7.0 PDI usage (old)
+
+```kotlin
+AuthorizationMethod.presentationDuringIssuance(
+    selectCredentialsForPresentation = { presentationRequest -> // 0.7.0: returned Map<String, Map<FormatType, Any>>
+        val selectedCredentials: Map<String, Map<FormatType, Any>> = selectCredentials(presentationRequest)
+        return selectedCredentials
+    },
+    signVerifiablePresentation = { payload -> // 0.7.0: payload items are List<UnsignedVPTokenV2>; return List<VPTokenSigningResultV2>
+        val signedData: List<VPTokenSigningResultV2> = signDataForVP(payload)
+        return signedData
+    },
+    ldpVpSignatureSuite = "Ed25519Signature2020"
+)
+```
+
+### 1.0.0 PDI usage (new)
+
+```kotlin
+AuthorizationMethod.presentationDuringIssuance(
+        // Required only for ldp_vc — canonicalize JSON-LD and return base64url-encoded hash
+        return canonicalizeAndHash(data)
+    },
+    openid4vpWalletConfig = WalletConfig(), // Optional — use defaults or pass your config
+    selectCredentialsForPresentation = { presentationRequest -> // 1.0.0: return Map<String, List<Credential>> — flat list per descriptor/query ID
+        val selectedCredentials: Map<String, List<Credential>> = selectCredentials(presentationRequest)
+        return selectedCredentials
+    },
+    signVerifiablePresentation = { payload -> // 1.0.0: payload items are List<UnsignedVPToken>; return List<VPTokenSigningResult>
+        val signedData: List<VPTokenSigningResult> = signDataForVP(payload)
+        return signedData
+    }
+)
+```
+
+### Parameter mapping
+
+| 0.7.0 parameter                    | 1.0.0 parameter                    | Change                                                                          |
+|------------------------------------|------------------------------------|---------------------------------------------------------------------------------|
+| _(not present)_                    | `openid4vpWalletConfig`            | **New** — optional OpenID4VP wallet config                                      |
+| `selectCredentialsForPresentation` | `selectCredentialsForPresentation` | Return type changed: `Map<String, Map<FormatType, Any>>` → `Map<String, List<Credential>>` |
+| `signVerifiablePresentation`       | `signVerifiablePresentation`       | Return type changed: `List<VPTokenSigningResultV2>` → `List<VPTokenSigningResult>`      |
+| `ldpVpSignatureSuite`              | (not present)                      | Removed                                                                         |
+
+---
+
+## Before vs After: error handling
+
+### What stays the same
+
+- All exceptions are subclasses of `VCIClientException`.
+- `code` (`VCI-*`) and `message` continue to work as before.
+
+### New in 1.0.0
+
+Two structured fields are now available on `VCIClientException`:
+
+| New field                | Type      | Meaning                                                                                                        |
+|--------------------------|-----------|----------------------------------------------------------------------------------------------------------------|
+| `issuerErrorCode`        | `String?` | The `error` value returned by the issuer or authorization server in a structured OAuth/OID4VCI error response. |
+| `issuerErrorDescription` | `String?` | The `error_description` from the upstream server, or the raw body when structured parsing is not possible.     |
+
+Additionally, `code` now resolves to the **root** error code across the cause chain — if an exception wraps another `VCIClientException`, `code` carries the deepest `VCI-*` code rather than the wrapper's own code.
+
+### 0.7.0 error handling (old)
+
+```kotlin
+try {
+    val credentialResponse = vciClient.fetchCredentialUsingCredentialOffer(...)
+} catch (error: VCIClientException) {
+    when (error.code) {
+        "VCI-007" -> showRetryMessage()
+        else -> showGenericFailure(error.message)
+    }
+}
+```
+
+### 1.0.0 error handling (new)
+
+```kotlin
+try {
+    val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(...)
+} catch (error: VCIClientException) {
+    logger.error(
+        "VCI request failed. code=${error.code}, " +
+        "issuerCode=${error.issuerErrorCode ?: "nil"}, " +
+        "issuerDescription=${if (error.issuerErrorDescription != null) "<redacted>" else "nil"}, " +
+        "message=${error.message}"
+    )
+
+    when (error.code) {
+    "VCI-007" -> showRetryMessage()
+    "VCI-003" -> triggerTokenRefresh()
+    "VCI-011" -> showAuthorizationFailure()
+    else -> showGenericFailure()
+    }
+}
+```
+
+---
+
+## Removed and changed APIs
+
+> **Notice**
+>
+> 1.0.0 retains the core `VCIClient` entry point but removes the legacy low-level methods deprecated since 0.7.0, and renames the two primary download methods.
+
+### API changes
+
+| 0.7.0                                                                    | 1.0.0 status      | Change                                                                                                                                        |
+|--------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `fetchCredentialUsingCredentialOffer(...)`                               | **Renamed**       | Use `fetchCredentialsUsingCredentialOffer(...)`                                                                                               |
+| `fetchCredentialFromTrustedIssuer(...)`                                  | **Renamed**       | Use `fetchCredentialsFromTrustedIssuer(...)`                                                                                                  |
+| `getProofJwt` callback                                                   | **Replaced**      | Use `getProofs` returning `CredentialRequestProofs`                                                                                           |
+| `CredentialResponse.credential: AnyCodable`                              | **Replaced**      | Use `CredentialResponse.credentials: List<CredentialItem>`                                                                                        |
+| PDI `selectCredentialsForPresentation` → `Map<String, Map<FormatType, Any>>` | **Changed**       | Now returns `Map<String, List<Credential>>`                                                                                                          |
+| PDI `signVerifiablePresentation`                                         | **Changed**       | Input changed from `UnsignedVPTokenV2` to `UnsignedVPToken`. Return type changed from `List<VPTokenSigningResultV2>` to `List<VPTokenSigningResult>`. |
+| PDI _(no `openid4vpWalletConfig`)_                                       | **New parameter** | Optional OpenID4VP wallet configuration                                                                                                       |
+
+### APIs removed in 1.0.0
+
+| Removed method                            | Deprecated since | Replacement                                                                             |
+|-------------------------------------------|------------------|-----------------------------------------------------------------------------------------|
+| `requestCredentialByCredentialOffer(...)` | 0.7.0            | `fetchCredentialsUsingCredentialOffer(...)`                                             |
+| `requestCredentialFromTrustedIssuer(...)` | 0.7.0            | `fetchCredentialsFromTrustedIssuer(...)`                                                |
+| `requestCredential(...)`                  | 0.7.0            | `fetchCredentialsUsingCredentialOffer(...)` or `fetchCredentialsFromTrustedIssuer(...)` |
+
+### Unchanged APIs
+
+The following public methods are unchanged in 1.0.0:
+
+- `VCIClient(traceabilityId)`
+- `getIssuerMetadata(credentialIssuer =)`
+- `getCredentialConfigurationsSupported(credentialIssuer =)`
+
+---
+
+## Minimal working Kotlin example in 1.0.0
+
+```kotlin
+import io.mosip.vciclient.VCIClient
+
+fun downloadCredential(
+    traceabilityId: String,
+    credentialOffer: String,
+    clientId: String,
+    redirectUri: String
+): List<CredentialItem> {
+
+    val vciClient = VCIClient(traceabilityId = traceabilityId)
+
+    val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
+        credentialOffer = credentialOffer,
+        clientMetadata = ClientMetadata(clientId = clientId, redirectUri = redirectUri),
+        getTxCode = { inputMode, description, length -> // Prompt user for transaction code if required
+            return "userProvidedTxCode"
+        },
+        authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+                selectCredentialsForPresentation = { presentationRequest -> // Return wallet credentials matching the presentation request
+                    emptyMap()
+                },
+                signVerifiablePresentation = { payload -> // Sign VP payload; return List<VPTokenSigningResult>
+                    emptyList()
+                }
+            ),
+        AuthorizationMethod.redirectToWeb(openWebPage = { authorizationEndpoint -> // Open web view, complete authorization, return response params
+                emptyMap()
+            })
+        ),
+        getTokenResponse = { tokenRequest -> // Exchange authorization grant for access token
+            return TokenResponse(
+                accessToken = "accessToken",
+                cNonce = "nonce",
+                tokenType = "Bearer",
+                expiresIn = 3600,
+                cNonceExpiresIn = 3600
+            )
+        },
+        getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> // Build and sign proof JWT(s) using nonce and supported algorithms
+            val signedProofJwt = buildAndSignProofJwt(nonce = nonce, issuer = credentialIssuer)
+            return CredentialRequestProofs(proofs = listOf(signedProofJwt))
+        },
+        onCheckIssuerTrust = { credentialIssuer, issuerDisplay -> // Return true if the issuer is trusted by the wallet
+            return true
+        },
+        downloadTimeoutInMillis = 10_000
+    )
+
+    // credentialResponse.credentials is List<CredentialItem>
+    return credentialResponse.credentials
+}
+
+// Helpers (implement in your wallet app)
+
+fun buildAndSignProofJwt(nonce: String, issuer: String): String {
+    // Build the proof JWT header/payload, sign with your holder key, and return the compact serialization
+    return "eyJ..."
+}
+```
+
+Notes:
+- Replace stub callback bodies with your wallet's actual implementation.
+- `getProofs` replaces the old `getProofJwt` — wrap your signed JWT in `CredentialRequestProofs(proofs = listOf(...])`.
+- Iterate `credentialResponse.credentials` to access each downloaded credential via `.credential` (`AnyCodable`).
+
+---
+
+## Appendix: Key Kotlin types and entry points
+
+| Purpose                              | Type / File                                                             |
+|--------------------------------------|-------------------------------------------------------------------------|
+| Entry point                          | `VCIClient`                                                             |
+| Credential download (offer)          | `fetchCredentialsUsingCredentialOffer(...)`                             |
+| Credential download (trusted issuer) | `fetchCredentialsFromTrustedIssuer(...)`                                |
+| Proof callback return type           | `CredentialRequestProofs`                                               |
+| Credential response                  | `CredentialResponse`                                                    |
+| Individual credential in response    | `CredentialItem`                                                        |
+| Client registration details          | `ClientMetadata`                                                        |
+| Token exchange response              | `TokenResponse`                                                         |
+| Authorization flows                  | `AuthorizationMethod` (`.redirectToWeb`, `.presentationDuringIssuance`) |
+| Exception base type                  | `VCIClientException`                                                    |

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -56,24 +56,27 @@ The implementation follows:
 
 - Request credentials from OID4VCI-compliant credential issuers
 - Supports both:
-  - Issuer Initiated Flow (Credential Offer Flow).
-  - Wallet Initiated Flow (Trusted Issuer Flow).
+    - Issuer Initiated Flow (Credential Offer Flow).
+    - Wallet Initiated Flow (Trusted Issuer Flow).
 - Authorization server discovery for both flows
 - PKCE-compliant OAuth 2.0 Authorization Code flow (RFC 7636)
-  - PKCE session is managed internally by the library
+    - PKCE session is managed internally by the library
 - Well-defined **exception handling** with `VCI-XXX` error codes (see more on [this](#-error-handling))
 - Support for multiple Credential formats:
-  - `ldp_vc`
-  - `mso_mdoc`
-  - `vc+sd-jwt` / `dc+sd-jwt`
+    - `ldp_vc`
+    - `mso_mdoc`
+    - `vc+sd-jwt` / `dc+sd-jwt`
 
 [//]: # (The reference for PDI  is intentionally pointing to kotlin library master branch to be release agnostic, as the PDI support is available for both kotlin and kotlin libraries. The documentation for PDI support is also common for both libraries, hence it is placed in the common doc folder in the root of the repository.)
-- Presentation During Issuance (PDI) support for both download flows (For more details on PDI support, please refer to the [Presentation During Issuance documentation](https://github.com/inji/inji-vci-client/tree/master/doc/presentation-during-issuance-support.md))
+- Presentation During Issuance (PDI) support for both download flows (For more details on PDI support, please refer to the [Presentation During Issuance documentation](https://github.com/inji/inji-vci-client/tree/master/docs/presentation-during-issuance-support.md))
 
 ## Requirements
 
-- **Kotlin:** 5.7+
-- **Android:** 13.0+
+- **Kotlin:** 1.9.23
+- **Java compatibility:**
+    - Java 17 (`sourceCompatibility`/`targetCompatibility` 17, `jvmTarget` 17)
+- **Android SDK compatibility:**
+    - `minSdk` 23, `compileSdk` 34
 
 ---
 
@@ -91,12 +94,12 @@ implementation("io.inji:inji-vci-client:1.0.0")
 
 ### Typical Workflow
 
-```
+```text
 1. Initialise → VCIClient(traceabilityId)
 2. Discover   → getIssuerMetadata() / getCredentialConfigurationsSupported()
 3. Download   → fetchCredentialsUsingCredentialOffer()   [issuer-initiated]
               → fetchCredentialsFromTrustedIssuer()      [wallet-initiated]
-4. Render     → read credentialResponse.credentials (List<CredentialItem>)
+4. Render     → read credentialResponse.credentials?.orEmpty() (List<CredentialItem>?)
 ```
 
 ### Quick Start Example
@@ -109,20 +112,21 @@ val vciClient = VCIClient(traceabilityId = "wallet-app-101")
 val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
     credentialOffer = deepLinkOrCredentialOfferURI,
     clientMetadata = ClientMetadata(clientId = "my-wallet", redirectUri = "https://my-wallet.example/callback"),
-    authorizationMethods = listOf(
+    getTxCode = { inputMode, description, length -> "sampleTxCode" },
+    authorizations = listOf(
         AuthorizationMethod.redirectToWeb(openWebPage = { url -> openBrowserAndReturnParams(url) })
     ),
     getTokenResponse = { tokenRequest -> // Exchange authorization grant for access token
         return TokenResponse(accessToken = "...", cNonce = "...", tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
     },
     getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> // Sign proof JWT and wrap it
-        return CredentialRequestProofs(proofs = listOf(buildAndSignProofJwt(nonce = nonce)))
+        return CredentialRequestProofs(proofs = listOf(buildAndSignProofJwt(nonce = nonce, issuer = credentialIssuer)))
     }
 )
 
-// credentialResponse.credentials is List<CredentialItem>
-for item in credentialResponse.credentials {
-    renderCredential(item.credential) // item.credential is AnyCodable
+// credentialResponse.credentials is List<CredentialItem>?
+for (item in credentialResponse.credentials?.orEmpty()) {
+    renderCredential(item.credential) // item.credential is JsonElement?
 }
 ```
 
@@ -132,8 +136,8 @@ for item in credentialResponse.credentials {
 
 | Method | Purpose | Returns |
 |--------|---------|---------|
-| `getIssuerMetadata(credentialIssuer =)` | Fetches raw issuer well-known metadata | `Map<String, Any>` |
-| `getCredentialConfigurationsSupported(credentialIssuer =)` | Fetches supported credential configurations | `Map<String, Any>` |
+| `getIssuerMetadata(credentialIssuer = ...)` | Fetches raw issuer well-known metadata | `Map<String, Any>` |
+| `getCredentialConfigurationsSupported(credentialIssuer = ...)` | Fetches supported credential configurations | `Map<String, Any>` |
 | `fetchCredentialsUsingCredentialOffer(...)` | Downloads credentials via issuer-initiated (credential offer) flow | `CredentialResponse` |
 | `fetchCredentialsFromTrustedIssuer(...)` | Downloads credentials via wallet-initiated (trusted issuer) flow | `CredentialResponse` |
 
@@ -178,10 +182,10 @@ Retrieve the issuer metadata from the credential issuer's well-known endpoint.
 val issuerMetadata: Map<String, Any> = vciClient.getIssuerMetadata(credentialIssuer = "https://example.com/issuer")
     
 //the response looks similar to this
-Map<String, Any> = [
-    "credential_issuer": "https://example.com/issuer",
-    "credential_endpoint": "https://example.com/issuer/credential"
-]
+mapOf(
+    "credential_issuer" to "https://example.com/issuer",
+    "credential_endpoint" to "https://example.com/issuer/credential"
+)
 ```
 
 ### 2. Obtain Credential Configurations Supported
@@ -209,25 +213,25 @@ val credentialConfigurationsSupported : Map<String, Any> = vciClient.getCredenti
 )
 
 //The response looks similar to this
-Map<String, Any> = [
-    "credentialConfigId-1": [
-        "format": "ldp_vc",
-        "credential_definition": [
-            "type": ["VerifiableCredential", "ExampleCredential"]
-        ]
-    ],
-    "credentialConfigId-2": [
-        "format": "mso_mdoc",
-        "doctype": "org.iso.18013.5.1.mDL"
-    ],
-    "credentialConfigId-3": [
-        "format": "jwt_vc_json",
-        "credential_definition": [
-            "type": ["VerifiableCredential", "ExampleJwtCredential"],
-        ],
-        "scope": "ExampleJwtCredential"
-    ]
-]
+mapOf(
+    "credentialConfigId-1" to mapOf(
+        "format" to "ldp_vc",
+        "credential_definition" to mapOf(
+            "type" to listOf("VerifiableCredential", "ExampleCredential")
+        )
+    ),
+    "credentialConfigId-2" to mapOf(
+        "format" to "mso_mdoc",
+        "doctype" to "org.iso.18013.5.1.mDL"
+    ),
+    "credentialConfigId-3" to mapOf(
+        "format" to "jwt_vc_json",
+        "credential_definition" to mapOf(
+            "type" to listOf("VerifiableCredential", "ExampleJwtCredential")
+        ),
+        "scope" to "ExampleJwtCredential"
+    )
+)
 ```
 
 ### 3. Request Credential
@@ -257,7 +261,7 @@ Both methods use the OpenID4VCI 1.0-facing proof callback and return a normalize
 | credentialOffer         | String                        | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                            |
 | clientMetadata          | ClientMetadata                | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
 | getTxCode               | TxCodeCallback                | No       | N/A           | Optional callback for TX Code in pre-authorized flows                                                                                                                  |
-| authorizationMethods    | [AuthorizationMethod]         | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
+| authorizationMethods    | List<AuthorizationMethod>     | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
 | getTokenResponse        | TokenResponseCallback         | Yes      | N/A           | Callback that exchanges the authorization grant for an access token                                                                                                    |
 | getProofs               | ProofsCallback                | Yes      | N/A           | Callback that prepares the proof set for the credential request, returning a `CredentialRequestProofs`                                                                 |
 | onCheckIssuerTrust      | CheckIssuerTrustCallback      | No       | nil           | Optional callback to confirm that the issuer is trusted                                                                                                                |
@@ -269,9 +273,9 @@ An instance of `CredentialResponse` containing:
 
 | Name                      | Type             | Description                                                                                                |
 |---------------------------|------------------|------------------------------------------------------------------------------------------------------------|
-| credentials               | List<CredentialItem> | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`AnyCodable`)  |
-| credentialConfigurationId | String           | The identifier of the respective supported credential from well-known response                             |
-| credentialIssuer          | String           | URI of the Credential Issuer                                                                               |
+| credentials               | List<CredentialItem>? | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`JsonElement?`) |
+| credentialConfigurationId | String?          | The identifier of the respective supported credential from well-known response                             |
+| credentialIssuer          | String?          | URI of the Credential Issuer                                                                               |
 
 ##### Example usage
 
@@ -281,7 +285,7 @@ val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
     clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
     getTxCode = { inputMode, description, length -> "sampleTxCode"
     },
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
             selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
             signVerifiablePresentation = signVerifiablePresentationCallback()
@@ -303,9 +307,9 @@ val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
     downloadTimeoutInMillis = 10_000
 )
 
-credentialResponse.credentials // List<CredentialItem>; each item's `credential` is an AnyCodable
-credentialResponse.credentialConfigurationId // eg - "DriversLicense"
-credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
+credentialResponse.credentials?.orEmpty() // List<CredentialItem>?; each item's `credential` is a JsonElement?
+credentialResponse.credentialConfigurationId // String?
+credentialResponse.credentialIssuer // String?
 ```
 
 ### 3.2 Request Credential from Trusted Issuer
@@ -323,7 +327,7 @@ credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
 | credentialIssuer          | String                     | Yes      | N/A           | URI of the credential issuer                                                                                                                                           |
 | credentialConfigurationId | String                     | Yes      | N/A           | Identifier of the supported credential configuration                                                                                                                  |
 | clientMetadata            | ClientMetadata             | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
-| authorizationMethods      | [AuthorizationMethod]      | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
+| authorizationMethods      | List<AuthorizationMethod> | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
 | getTokenResponse          | TokenResponseCallback      | Yes      | N/A           | Callback that exchanges the authorization grant for an access token                                                                                                    |
 | getProofs                 | ProofsCallback             | Yes      | N/A           | Callback that prepares the proof set for the credential request, returning a `CredentialRequestProofs`                                                                 |
 | downloadTimeoutInMillis   | Int64                      | No       | 10000         | Timeout for the credential request to the issuer                                                                                                                       |
@@ -334,9 +338,9 @@ An instance of `CredentialResponse` containing:
 
 | Name                      | Type             | Description                                                                                                |
 |---------------------------|------------------|------------------------------------------------------------------------------------------------------------|
-| credentials               | List<CredentialItem> | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`AnyCodable`)  |
-| credentialConfigurationId | String           | The identifier of the respective supported credential from well-known response                             |
-| credentialIssuer          | String           | URI of the Credential Issuer                                                                               |
+| credentials               | List<CredentialItem>? | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`JsonElement?`) |
+| credentialConfigurationId | String?          | The identifier of the respective supported credential from well-known response                             |
+| credentialIssuer          | String?          | URI of the Credential Issuer                                                                               |
 
 #### Example usage
 
@@ -348,7 +352,7 @@ val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
         clientId = "sample-client-id",
         redirectUri = "https://sample-wallet.com/callback"
     ),
-    authorizationMethods = listOf(
+    authorizations = listOf(
         AuthorizationMethod.presentationDuringIssuance(
             selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
             signVerifiablePresentation = signVerifiablePresentationCallback()
@@ -368,9 +372,9 @@ val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
     downloadTimeoutInMillis = 10_000
 )
 
-credentialResponse.credentials // List<CredentialItem>; each item's `credential` is an AnyCodable
-credentialResponse.credentialConfigurationId // eg - "DriversLicense"
-credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
+credentialResponse.credentials?.orEmpty() // List<CredentialItem>?; each item's `credential` is a JsonElement?
+credentialResponse.credentialConfigurationId // String?
+credentialResponse.credentialIssuer // String?
 ```
 
 ##### Authorizations
@@ -514,7 +518,7 @@ try {
         credentialOffer = credentialOffer,
         clientMetadata = clientMetadata,
         getTxCode = getTxCode,
-        authorizationMethods = authorizationMethods,
+        authorizations = authorizationMethods,
         getTokenResponse = getTokenResponse,
         getProofs = getProofs
     )
@@ -564,9 +568,9 @@ Mock-based tests are available covering:
 
 ## Documentation
 
-- Architecture decisions are documented in the [INJI VCI Client ADR directory](https://github.com/inji/inji-vci-client/tree/master/doc/adr).
-- Documentation of the features are available in the [INJI VCI Client docs directory](https://github.com/inji/inji-vci-client/tree/master/doc).
-- The OpenID4VCI 1.0 migration and Draft-13 compatibility design for this Kotlin library is documented in [ADR-0001](docs/adr/0001-openid4vci-v1-migration.md).
+- Architecture decisions are documented in the [INJI VCI Client ADR directory](https://github.com/inji/inji-vci-client/tree/master/docs/adr).
+- Documentation of the features are available in the [INJI VCI Client docs directory](https://github.com/inji/inji-vci-client/tree/master/docs).
+- The OpenID4VCI 1.0 migration and Draft-13 compatibility design for this Kotlin library is documented in [ADR-0001](../docs/adr/0001-openid4vci-v1-migration.md).
 
 **Note: The Android library is available in the [INJI VCI Client repository](https://github.com/inji/inji-vci-client).**
 
@@ -574,10 +578,10 @@ Mock-based tests are available covering:
 
 ## Library Implementations Available In
 
-This library is officially supported and available in both Kotlin and Kotlin, ensuring seamless integration across Android and Android platforms:
+This library is officially supported and available in both Kotlin and Swift, ensuring seamless integration across Android and iOS platforms:
 
-* [Kotlin](https://github.com/inji/inji-vci-client/tree/master/kotlin)
 * [Kotlin](.)
+* [Swift](https://github.com/inji/inji-vci-client-ios-swift)
 
 ---
 
@@ -597,7 +601,7 @@ A complete sample app demonstrating credential issuance flows, proof JWT signing
 
 ## Migration Guide
 
-For information on upgrading between versions, see the [Migration Guide](docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md).
+For information on upgrading between versions, see the [Migration Guide](../docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md).
 
 ---
 
@@ -615,5 +619,4 @@ For information on upgrading between versions, see the [Migration Guide](docs/mi
 * **Proof JWT:** A signed JWT included in the credential request to prove the wallet controls the key associated with the credential subject.
 * **PDI (Presentation During Issuance):** An authorization flow where the wallet presents an existing credential to the issuer as proof of identity, instead of using a web redirect.
 * **JWT:** JSON Web Token. A digitally signed token format used for secure transmission of claims.
-* **AnyCodable:** A Kotlin type-erased `Codable` wrapper used to represent the credential payload, which may be a JSON object, string, or other format depending on the credential type.
-
+* **JsonElement:** A Gson JSON element (`com.google.gson.JsonElement`) used to represent the credential payload. Use schema-aware deserialization to map it into typed models where needed.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,13 +1,54 @@
 # INJI VCI Client
 
-The **Inji VCI Client** is a Kotlin-based library built to simplify credential issuance via [OpenID for Verifiable Credential Issuance (OID4VCI)](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) protocol.
-It supports **Issuer Initiated (Credential Offer)** and **Wallet Initiated (Trusted Issuer)** flows, with secure proof handling, PKCE support, and custom error handling.
+The **Inji VCI Client Kotlin** is a Kotlin library that simplifies credential issuance via the [OpenID for Verifiable Credential Issuance (OID4VCI)](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) protocol. It handles the full credential download lifecycle — issuer discovery, authorization, proof construction, and credential retrieval — so your wallet can focus on user experience and key management.
 
 ---
 
-## Specifications supported
+## Table of Contents
 
-The implementation follows
+- [Overview](#overview)
+- [Specifications Supported](#specifications-supported)
+- [Features](#features)
+- [Requirements](#requirements)
+- [Installation](#-installation)
+- [Getting Started](#getting-started)
+- [API Overview](#-api-overview)
+- [Security Support](#-security-support)
+- [Error Handling](#-error-handling)
+- [Testing](#-testing)
+- [Example App](#example-app)
+- [Migration Guide](#migration-guide)
+- [Documentation](#documentation)
+- [Library Implementations](#library-implementations-available-in)
+- [Glossary](#glossary)
+
+---
+
+## Overview
+
+The VCI Client library is a ready-to-integrate wallet-side solution for credential issuance. It takes care of the complexity behind OID4VCI — including issuer metadata discovery, PKCE-managed authorization, proof JWT construction, and credential download — enabling faster integration with less engineering effort.
+
+**Key Responsibilities:**
+
+* **VCI Client Library**
+
+   * Handles OID4VCI protocol workflows and compliance
+   * Manages PKCE session, authorization server discovery, and token exchange
+   * Supports both OID4VCI 1.0 and draft 13 issuers transparently
+
+* **Library Consumer (Wallet App)**
+
+   * Owns user consent and credential rendering
+   * Performs cryptographic proof signing
+   * Implements authorization callbacks (web redirect / Presentation During Issuance)
+
+> Consumer of this library is responsible for processing and rendering the credential after it is downloaded.
+
+---
+
+## Specifications Supported
+
+The implementation follows:
 - OpenID for Verifiable Credential Issuance 1.0
 - OpenID for Verifiable Credential Issuance draft 13 compatibility for issuers that still expose the older metadata and request/response format
 
@@ -26,38 +67,77 @@ The implementation follows
   - `mso_mdoc`
   - `vc+sd-jwt` / `dc+sd-jwt`
 
-[//]: # (The reference for PDI is intentionally pointing to the common doc folder in the root of the repository, as the PDI support and its documentation are common for both the Kotlin and Swift libraries.)
-- Presentation During Issuance (PDI) support for both download flows (For more details on PDI support, please refer to the [Presentation During Issuance documentation](../doc/presentation-during-issuance-support.md))
+[//]: # (The reference for PDI  is intentionally pointing to kotlin library master branch to be release agnostic, as the PDI support is available for both kotlin and kotlin libraries. The documentation for PDI support is also common for both libraries, hence it is placed in the common doc folder in the root of the repository.)
+- Presentation During Issuance (PDI) support for both download flows (For more details on PDI support, please refer to the [Presentation During Issuance documentation](https://github.com/inji/inji-vci-client/tree/master/doc/presentation-during-issuance-support.md))
 
-> Consumer of this library is responsible for processing and rendering the credential after it is downloaded.
+## Requirements
 
-## Library implementations available in:
-This library is officially supported and available in both Kotlin and Swift, ensuring seamless integration across Android and iOS platforms. The references for both implementations are provided below:
-
-* [Kotlin](.)
-* [Swift](https://github.com/inji/inji-vci-client-ios-swift)
+- **Kotlin:** 5.7+
+- **Android:** 13.0+
 
 ---
 
 ## 📦 Installation
 
-Add the following dependency to your `build.gradle` to include the library from **Maven Central**:
+Add the following dependency:
 
-```groovy
-implementation "io.inji:inji-vci-client:1.0.0"
+```kotlin
+implementation("io.inji:inji-vci-client:1.0.0")
 ```
 
-## What's New in 1.0.0
+---
 
-Version `1.0.0` adds support for the final **OpenID for Verifiable Credential Issuance 1.0** specification while retaining backward compatibility with OID4VCI draft 13. The highlights below cover everything added since `0.7.0`:
+## Getting Started
 
-- **OID4VCI 1.0 support with retained draft 13 support** - The library auto-detects the spec version of the issuer from its metadata and builds the credential request accordingly, so a single integration works against both 1.0 and draft 13 issuers.
-- **Credential download methods renamed (and now return multiple credentials)** - `fetchCredentialUsingCredentialOffer` and `fetchCredentialFromTrustedIssuer` are now `fetchCredentialsUsingCredentialOffer` and `fetchCredentialsFromTrustedIssuer`.
-- **New `getProofs` callback** - The single-proof `getProofJwt` callback is replaced by `getProofs`, which returns a `CredentialRequestProofs` object and allows supplying one or more proofs in a single credential request, as per OID4VCI 1.0.
-- **`CredentialResponse` now exposes a `credentials` list** - Instead of a single `credential` field, the response carries a `credentials` list (`List<CredentialItem>`), aligning with the OID4VCI 1.0 credential response structure.
-- **Legacy APIs removed** - `requestCredentialByCredentialOffer`, `requestCredentialFromTrustedIssuer`, and `requestCredential` (along with the `IssuerMetaData` DTO) have been removed. Migrate to the `fetchCredentials*` methods.
-- **Structured error handling** - `VCIClientException` now carries `issuerErrorCode` and `issuerErrorDescription` alongside `code` and `message`, and `code` resolves to the root error code across the cause chain, so consumers can distinguish library failures from issuer/authorization-server error payloads (see [Error Handling](#-error-handling)).
-- **Issuer identity validation** - Issuer metadata fetches now validate that the `credential_issuer` returned by the well-known endpoint matches the requested issuer, per [OID4VCI Section 13.5](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#section-13.5).
+### Typical Workflow
+
+```
+1. Initialise → VCIClient(traceabilityId)
+2. Discover   → getIssuerMetadata() / getCredentialConfigurationsSupported()
+3. Download   → fetchCredentialsUsingCredentialOffer()   [issuer-initiated]
+              → fetchCredentialsFromTrustedIssuer()      [wallet-initiated]
+4. Render     → read credentialResponse.credentials (List<CredentialItem>)
+```
+
+### Quick Start Example
+
+```kotlin
+import io.mosip.vciclient.VCIClient
+
+val vciClient = VCIClient(traceabilityId = "wallet-app-101")
+
+val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
+    credentialOffer = deepLinkOrCredentialOfferURI,
+    clientMetadata = ClientMetadata(clientId = "my-wallet", redirectUri = "https://my-wallet.example/callback"),
+    authorizationMethods = listOf(
+        AuthorizationMethod.redirectToWeb(openWebPage = { url -> openBrowserAndReturnParams(url) })
+    ),
+    getTokenResponse = { tokenRequest -> // Exchange authorization grant for access token
+        return TokenResponse(accessToken = "...", cNonce = "...", tokenType = "Bearer", expiresIn = 3600, cNonceExpiresIn = 3600)
+    },
+    getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> // Sign proof JWT and wrap it
+        return CredentialRequestProofs(proofs = listOf(buildAndSignProofJwt(nonce = nonce)))
+    }
+)
+
+// credentialResponse.credentials is List<CredentialItem>
+for item in credentialResponse.credentials {
+    renderCredential(item.credential) // item.credential is AnyCodable
+}
+```
+
+> **Note:** The crypto implementations like signing the proof JWT are kept in your wallet app. The library handles OID4VCI protocol mechanics.
+
+### Core Methods
+
+| Method | Purpose | Returns |
+|--------|---------|---------|
+| `getIssuerMetadata(credentialIssuer =)` | Fetches raw issuer well-known metadata | `Map<String, Any>` |
+| `getCredentialConfigurationsSupported(credentialIssuer =)` | Fetches supported credential configurations | `Map<String, Any>` |
+| `fetchCredentialsUsingCredentialOffer(...)` | Downloads credentials via issuer-initiated (credential offer) flow | `CredentialResponse` |
+| `fetchCredentialsFromTrustedIssuer(...)` | Downloads credentials via wallet-initiated (trusted issuer) flow | `CredentialResponse` |
+
+---
 
 ## 🏗️ Construction of VCIClient instance
 
@@ -65,7 +145,7 @@ Version `1.0.0` adds support for the final **OpenID for Verifiable Credential Is
 
 ```kotlin
 val traceabilityId = "sample-trace-id"
-val vciClient = VCIClient(traceabilityId)
+val vciClient = VCIClient(traceabilityId = traceabilityId)
 ```
 
 #### Parameters
@@ -88,22 +168,20 @@ Retrieve the issuer metadata from the credential issuer's well-known endpoint.
 
 #### Returns
 
-`IssuerMetadata` object containing details like `credential_endpoint`, `credential_issuer`, and other IssuerMetadata information from the well-known endpoint of Credential Issuer, which can be used by the consumer to display Issuer information, etc.
+`Map<String, Any>` dictionary containing details like `credential_endpoint`, `credential_issuer`, and other issuer metadata from the well-known endpoint of Credential Issuer, which can be used by the consumer to display Issuer information, etc.
 
 > Note: This method does not parse the metadata, it simply returns the raw Network response of well-known endpoint as a `Map<String, Any>`.
 
 #### Example Usage
 
 ```kotlin
-val issuerMetadata : Map<String, Any> = VCIClient(traceabilityId).getIssuerMetadata(
-    credentialIssuer = "https://example.com/issuer"
-)
-
-//The response looks similar to this
-mapOf(
-  "credential_issuer" to "https://example.com/issuer",
-  "credential_endpoint" to "https://example.com/issuer/credential",
-)
+val issuerMetadata: Map<String, Any> = vciClient.getIssuerMetadata(credentialIssuer = "https://example.com/issuer")
+    
+//the response looks similar to this
+Map<String, Any> = [
+    "credential_issuer": "https://example.com/issuer",
+    "credential_endpoint": "https://example.com/issuer/credential"
+]
 ```
 
 ### 2. Obtain Credential Configurations Supported
@@ -126,26 +204,40 @@ credential types, etc.
 #### Example Usage
 
 ```kotlin
-val credentialConfigurationsSupported : Map<String, Any> = VCIClient(traceabilityId).getCredentialConfigurationsSupported(
+val credentialConfigurationsSupported : Map<String, Any> = vciClient.getCredentialConfigurationsSupported(
     credentialIssuer = "https://example.com/issuer"
 )
 
 //The response looks similar to this
-mapOf(
-  "credentialConfigId-1" to mapOf(
-    "format" to "ldp_vc",
-    "credential_definition" to mapOf(
-        "type" to listOf("VerifiableCredential", "ExampleCredential")
-    )
-  ),
-  "credentialConfigId-2" to mapOf(
-    "format" to "mso_mdoc",
-    "doctype" to "org.iso.18013.5.1.mDL"
-  )
-)
+Map<String, Any> = [
+    "credentialConfigId-1": [
+        "format": "ldp_vc",
+        "credential_definition": [
+            "type": ["VerifiableCredential", "ExampleCredential"]
+        ]
+    ],
+    "credentialConfigId-2": [
+        "format": "mso_mdoc",
+        "doctype": "org.iso.18013.5.1.mDL"
+    ],
+    "credentialConfigId-3": [
+        "format": "jwt_vc_json",
+        "credential_definition": [
+            "type": ["VerifiableCredential", "ExampleJwtCredential"],
+        ],
+        "scope": "ExampleJwtCredential"
+    ]
+]
 ```
 
 ### 3. Request Credential
+
+Version `1.0.0` exposes two public credential download APIs:
+
+- `fetchCredentialsUsingCredentialOffer(...)` for issuer-initiated flows
+- `fetchCredentialsFromTrustedIssuer(...)` for wallet-initiated flows
+
+Both methods use the OpenID4VCI 1.0-facing proof callback and return a normalized plural response. When an issuer still behaves like Draft-13, the library keeps the compatibility routing internal and still returns the 1.0 response shape.
 
 ### 3.1 Request Credential using Credential Offer
 
@@ -155,217 +247,159 @@ mapOf(
 - This method allows you to fetch credential(s) using a credential offer, which can be either an embedded JSON or a URI pointing to the credential offer.
 - It supports both **Pre-Authorization** and **Authorization** flows.
 - The library handles the PKCE flow internally.
-- User-trust based credential download supported through onCheckIssuerTrust callback.
+- User-trust based credential download supported through `onCheckIssuerTrust` callback.
 - This method is the recommended way to request credential using credential offer.
 
 ##### Parameters
 
-| Name                    | Type                     | Required | Default Value | Description                                                                                                                                                            |
-|-------------------------|--------------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                            |
-| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
-| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                                                                                            |
-| authorizations          | List<AuthorizationMethod>| Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [see authorization details](#authorizations) |
-| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                           |
-| getProofs               | ProofsCallback           | Yes      | N/A           | Callback function to prepare the proof(s) for the Credential Request, returning a `CredentialRequestProofs`                                                            |
-| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | null          | Callback function to get user trust with the Credential Issuer                                                                                                         |
-| downloadTimeoutInMillis | Long                     | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                         |
+| Name                    | Type                          | Required | Default Value | Description                                                                                                                                                            |
+|-------------------------|-------------------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialOffer         | String                        | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                            |
+| clientMetadata          | ClientMetadata                | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
+| getTxCode               | TxCodeCallback                | No       | N/A           | Optional callback for TX Code in pre-authorized flows                                                                                                                  |
+| authorizationMethods    | [AuthorizationMethod]         | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
+| getTokenResponse        | TokenResponseCallback         | Yes      | N/A           | Callback that exchanges the authorization grant for an access token                                                                                                    |
+| getProofs               | ProofsCallback                | Yes      | N/A           | Callback that prepares the proof set for the credential request, returning a `CredentialRequestProofs`                                                                 |
+| onCheckIssuerTrust      | CheckIssuerTrustCallback      | No       | nil           | Optional callback to confirm that the issuer is trusted                                                                                                                |
+| downloadTimeoutInMillis | Int64                         | No       | 10000         | Timeout for the credential request to the issuer                                                                                                                       |
 
 ##### Returns
 
 An instance of `CredentialResponse` containing:
 
-| Name                      | Type                  | Description                                                                                                  |
-|---------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------|
-| credentials               | List<CredentialItem>  | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`JsonElement`)   |
-| credentialConfigurationId | String                | The identifier of the respective supported credential from well-known response                               |
-| credentialIssuer          | String                | URI of the Credential Issuer                                                                                  |
+| Name                      | Type             | Description                                                                                                |
+|---------------------------|------------------|------------------------------------------------------------------------------------------------------------|
+| credentials               | List<CredentialItem> | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`AnyCodable`)  |
+| credentialConfigurationId | String           | The identifier of the respective supported credential from well-known response                             |
+| credentialIssuer          | String           | URI of the Credential Issuer                                                                               |
 
 ##### Example usage
 
 ```kotlin
-val credentialResponse: CredentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
-  credentialOffer = "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
-  clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
-  getTxCode = object : TxCodeCallback {
-    override suspend fun invoke(p1: String?, p2: String?, p3: Int?): String {
-      // Handle the transaction code retrieval logic here
-      val txCode = "sampleTxCode"
-      return txCode
-    }
-  },
-  authorizations = listOf(
-      // Presentation During Issuance flow for authorization
-      AuthorizationMethod.PresentationDuringIssuance(
-          selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
-          signVerifiablePresentation = signVerifiablePresentationCallback()
-      ),
-      // Redirect to Web flow for Web view authorization
-      AuthorizationMethod.RedirectToWeb(openWebPage = openWebPageCallback())
-  ),
-  getTokenResponse = object : TokenResponseCallback {
-    override suspend fun invoke(tokenRequest: TokenRequest): TokenResponse {
-      // Handle the token response retrieval logic here
-      //Exchange authorization code for access token
-      return TokenResponse(
-        accessToken = "sampleAccessToken",
-        cNonce = "sampleNonce",
-        tokenType = "Bearer",
-        expiresIn = 3600,
-        cNonceExpiresIn = 3600,
-      )
-    }
-  },
-  getProofs = object : ProofsCallback {
-    override suspend fun invoke(
-      credentialIssuer: String,
-      nonce: String?,
-      proofSigningAlgorithmsSupported: List<String>
-    ): CredentialRequestProofs {
-      // Prepare and sign one or more proof JWTs with the private key as per the proofSigningAlgorithmsSupported
-      return CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
-    }
-  },
-  onCheckIssuerTrust = object : CheckIssuerTrustCallback {
-    override suspend fun invoke(
-      credentialIssuer: String,
-      issuerDisplay: List<Map<String, Any>>
-    ): Boolean {
-      // Handle the issuer trust check logic here
-      return true // Assume the issuer is trusted for this example
-    }
-  },
-  downloadTimeoutInMillis = 10000
+val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(
+    credentialOffer = "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
+    clientMetadata = ClientMetadata(clientId = "sample-client-id", redirectUri = "https://sample-wallet.com/callback"),
+    getTxCode = { inputMode, description, length -> "sampleTxCode"
+    },
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
+            signVerifiablePresentation = signVerifiablePresentationCallback()
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(
+            accessToken = "sampleAccessToken",
+            cNonce = "sampleNonce",
+            tokenType = "Bearer",
+            expiresIn = 3600,
+            cNonceExpiresIn = 3600
+        )
+    },
+    getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
+    },
+    onCheckIssuerTrust = { credentialIssuer, issuerDisplay -> true
+    },
+    downloadTimeoutInMillis = 10_000
 )
 
-//Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-val credentialResponse = vciClient.fetchCredentialsUsingCredentialOffer(credentialOffer, clientMetadata, getTxCode, authorizations, getTokenResponse, getProofs, onCheckIssuerTrust, downloadTimeoutInMillis)
-credentialResponse.credentials // List<CredentialItem>; each item's `credential` is a JsonElement. eg - JsonPrimitive("omdk...t")
+credentialResponse.credentials // List<CredentialItem>; each item's `credential` is an AnyCodable
 credentialResponse.credentialConfigurationId // eg - "DriversLicense"
 credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
 ```
 
-#### requestCredentialByCredentialOffer (removed in 1.0)
-
-> ⚠️ **Removed in 1.0**: `requestCredentialByCredentialOffer` (deprecated since `0.7.0`) has been removed. Use [`fetchCredentialsUsingCredentialOffer`](#fetchcredentialsusingcredentialoffer) instead, which supports both Pre-Authorization and Authorization flows along with the different authorization methods (Redirect to Web / Presentation During Issuance).
-
 ### 3.2 Request Credential from Trusted Issuer
 
 #### fetchCredentialsFromTrustedIssuer
+
 - Method: `fetchCredentialsFromTrustedIssuer`
 - It supports **Authorization** flow.
 - The library handles the PKCE flow internally.
 
 #### Parameters
 
-| Name                      | Type                  | Required | Default Value | Description                                                                                                                                                                               |
-|---------------------------|-----------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                                                                                                              |
-| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                                                                                                                |
-| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                                       |
-| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                                              |
-| authorizations            | List<AuthorizationMethod> | Yes  | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [see authorization details](#authorizations)                     |
-| getProofs                 | ProofsCallback        | Yes      | N/A           | Callback function to prepare the proof(s) for the Credential Request, returning a `CredentialRequestProofs`                                                                               |
-| downloadTimeoutInMillis   | Long                  | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                                            |
+| Name                      | Type                       | Required | Default Value | Description                                                                                                                                                            |
+|---------------------------|----------------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialIssuer          | String                     | Yes      | N/A           | URI of the credential issuer                                                                                                                                           |
+| credentialConfigurationId | String                     | Yes      | N/A           | Identifier of the supported credential configuration                                                                                                                  |
+| clientMetadata            | ClientMetadata             | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
+| authorizationMethods      | [AuthorizationMethod]      | Yes      | N/A           | Supported authorization callbacks for interactive flows [see authorization details](#authorizations)                                                                   |
+| getTokenResponse          | TokenResponseCallback      | Yes      | N/A           | Callback that exchanges the authorization grant for an access token                                                                                                    |
+| getProofs                 | ProofsCallback             | Yes      | N/A           | Callback that prepares the proof set for the credential request, returning a `CredentialRequestProofs`                                                                 |
+| downloadTimeoutInMillis   | Int64                      | No       | 10000         | Timeout for the credential request to the issuer                                                                                                                       |
 
 #### Returns
 
 An instance of `CredentialResponse` containing:
 
-| Name                      | Type                  | Description                                                                                                  |
-|---------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------|
-| credentials               | List<CredentialItem>  | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`JsonElement`)   |
-| credentialConfigurationId | String                | The identifier of the respective supported credential from well-known response                               |
-| credentialIssuer          | String                | URI of the Credential Issuer                                                                                  |
+| Name                      | Type             | Description                                                                                                |
+|---------------------------|------------------|------------------------------------------------------------------------------------------------------------|
+| credentials               | List<CredentialItem> | The credential(s) downloaded from the Issuer. Each `CredentialItem` exposes a `credential` (`AnyCodable`)  |
+| credentialConfigurationId | String           | The identifier of the respective supported credential from well-known response                             |
+| credentialIssuer          | String           | URI of the Credential Issuer                                                                               |
 
 #### Example usage
 
 ```kotlin
-val credentialResponse: CredentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
-  credentialIssuer = "https://sample-issuer.com",
-  credentialConfigurationId = "DriversLicense",
-  clientMetadata = ClientMetadata(
-    clientId = "sample-client-id",
-    redirectUri = "https://sample-wallet.com/callback"
-  ),
-  getTokenResponse = object : TokenResponseCallback {
-    override suspend fun invoke(tokenRequest: TokenRequest): TokenResponse {
-      // Handle the token response retrieval logic here
-      //Exchange authorization code for access token
-      return TokenResponse(
-        accessToken = "sampleAccessToken",
-        cNonce = "sampleNonce",
-        tokenType = "Bearer",
-        expiresIn = 3600,
-        cNonceExpiresIn = 3600,
-      )
-    }
-  },
-  authorizations = listOf(
-    // Presentation During Issuance flow for authorization
-    AuthorizationMethod.PresentationDuringIssuance(
-        selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
-        signVerifiablePresentation = signVerifiablePresentationCallback()
+val credentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(
+    credentialIssuer = "https://sample-issuer.com",
+    credentialConfigurationId = "DriversLicense",
+    clientMetadata = ClientMetadata(
+        clientId = "sample-client-id",
+        redirectUri = "https://sample-wallet.com/callback"
     ),
-    // Redirect to Web flow for Web view authorization
-    AuthorizationMethod.RedirectToWeb(openWebPage = openWebPageCallback())
-  ),
-  getProofs = object : ProofsCallback {
-    override suspend fun invoke(
-      credentialIssuer: String,
-      nonce: String?,
-      proofSigningAlgorithmsSupported: List<String>
-    ): CredentialRequestProofs {
-      // Prepare and sign one or more proof JWTs with the private key as per the proofSigningAlgorithmsSupported
-      return CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
-    }
-  },
-  downloadTimeoutInMillis = 10000
+    authorizationMethods = listOf(
+        AuthorizationMethod.presentationDuringIssuance(
+            selectCredentialsForPresentation = selectCredentialsForPresentationCallback(),
+            signVerifiablePresentation = signVerifiablePresentationCallback()
+        ),
+        AuthorizationMethod.redirectToWeb(openWebPage = openWebPageCallback())
+    ),
+    getTokenResponse = { tokenRequest -> TokenResponse(
+            accessToken = "sampleAccessToken",
+            cNonce = "sampleNonce",
+            tokenType = "Bearer",
+            expiresIn = 3600,
+            cNonceExpiresIn = 3600
+        )
+    },
+    getProofs = { credentialIssuer, nonce, proofSigningAlgorithmsSupported -> CredentialRequestProofs(proofs = listOf("sampleProofJwt"))
+    },
+    downloadTimeoutInMillis = 10_000
 )
 
-//Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-val mdocCredentialResponse = vciClient.fetchCredentialsFromTrustedIssuer(credentialIssuer, credentialConfigurationId, clientMetadata, getTokenResponse, authorizations, getProofs, downloadTimeoutInMillis)
-credentialResponse.credentials // List<CredentialItem>; each item's `credential` is a JsonElement. eg - JsonPrimitive("omdk...t")
+credentialResponse.credentials // List<CredentialItem>; each item's `credential` is an AnyCodable
 credentialResponse.credentialConfigurationId // eg - "DriversLicense"
 credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
 ```
 
-#### requestCredentialFromTrustedIssuer (removed in 1.0)
-
-> ⚠️ **Removed in 1.0**: `requestCredentialFromTrustedIssuer` (deprecated since `0.7.0`) has been removed. Use [`fetchCredentialsFromTrustedIssuer`](#fetchcredentialsfromtrustedissuer) instead, which supports the different authorization methods (Redirect to Web / Presentation During Issuance).
-
 ##### Authorizations
-The `authorizations` parameter is a list of `AuthorizationMethod` objects indicating the supported authorizations of the Wallet for the download flow. Currently, library supports two authorization flows - _Redirect To Web_ and _Presentation During Issuance_. Library exposes the supported authorization flows via class - `AuthorizationMethod`
+
+The `authorizationMethods` parameter is a list of supported wallet authorization flows. The library currently supports two authorization flows - _Redirect To Web_ and _Presentation During Issuance_.
 
 1. Redirect To Web (for Authorization flow)
 
-Redirect the user to the authorization endpoint (authorization server) in a web view or browser, and get the authorization response parameters back after successful authorization.
+Redirect the user to the authorization endpoint in a web view or browser and return the authorization response parameters after successful authorization.
 
 **Parameters :**
 
 | Name        | Type                | Required | Default Value | Description                                                                                                                                                                         |
 |-------------|---------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| openWebPage | OpenWebPageCallback | Yes      | N/A           | Callback function to open the authorization endpoint in a web view or browser, and return the authorization response parameters (e.g., code, state) after successful authorization. |
+| openWebPage | OpenWebPageCallback | Yes      | N/A           | Callback that opens the authorization endpoint and returns the authorization response parameters such as `code` and `state`                                                         |
 
 **Example usage**
 ```kotlin
-AuthorizationMethod.RedirectToWeb(
-  openWebPage = object : OpenWebPageCallback {
-    override suspend fun invoke(authorizationEndpoint: String): Map<String, Any> {
-        // Handle the user authorization logic here
-        // Open a web view or browser with the authorizationEndpoint
-        // Return the authorization response parameters (e.g., code, state)
-        val result: Map<String, Any> = openWebViewAndGetResult(authorizationEndpoint)
+AuthorizationMethod.redirectToWeb(
+    openWebPage = { authorizationEndpoint -> val result: Map<String, Any> = openWebViewAndGetResult(authorizationEndpoint)
         return result
     }
-  }
 )
 ```
 > Note: The Redirect to Web flow for an interactive authorization flow is exposed as an experimental API, and is expected to be improved in future releases.
 
 2. Presentation During Issuance
 
-Presentation During Issuance flow allows the Wallet to present a verifiable presentation to the Credential Issuer during the credential download process, which can be used by the issuer to verify certain claims about the user before issuing the credential. The authorization for the download here is presentation of another credential (or a verifiable presentation) instead of user interaction-based authorization as in Redirect To Web flow.
+Presentation During Issuance allows the wallet to present a verifiable presentation to the credential issuer during the issuance flow, which can be used by the issuer to verify certain claims about the user before issuing the credential. The authorization for the download here is presentation of another credential (or a verifiable presentation) instead of user interaction-based authorization as in Redirect To Web flow.
 
 ###### Specification Reference
 
@@ -373,65 +407,47 @@ This implementation follows - [OpenID4VCI v1.1 Specification Commit](https://git
 
 > Note:
 > - While this library primarily implements OpenID4VCI 1.0 and draft 13, the Presentation During Issuance feature follows the v1.1 specification as mentioned above.
-> - For Presentation During Issuance flow, this VCI client library internally uses [inji-openid4vp](https://github.com/inji/inji-openid4vp/tree/master/kotlin) library to construct the VP and handle the presentation exchange with the issuer.
+> - For Presentation During Issuance, this library internally uses [inji-openid4vp](https://github.com/inji/inji-openid4vp) to construct the VP and handle the presentation exchange with the issuer.
+> 
+> The OpenID4VP request is expected to follow either:
+>
+> * the [**Digital Credentials Query Language (DCQL)**](https://openid.github.io/OpenID4VP/openid-4-verifiable-presentations-1_0-wg-draft.html#name-digital-credentials-query-l) request format, as defined in the OpenID4VP specification V1.0, or
+> * the [**DIF Presentation Exchange**](https://openid.net/specs/openid-4-verifiable-presentations-1_0-ID3.html#name-dif-presentation-exchange-2) request format, as defined in the Draft 23 OpenID4VP specification.
+
+
+###### Supported Response Modes
+
+The following response modes are supported:
+
+1. `iar_post`
+2. `iar_post.jwt`
+
 
 **Parameters :**
 
-| Name                             | Type                                     | Required | Default Value    | Description                                                                                                                                                                                                                                                                                                                                                                                            |
-|----------------------------------|------------------------------------------|----------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| selectCredentialsForPresentation | SelectCredentialsForPresentationCallback | Yes      | N/A              | Callback function to select credentials from the wallet to be presented to the issuer during issuance as per the Issuer's request. The callback will be invoked with a VP request (`AuthorizationRequest`); the Wallet uses this to ask the user to select credentials and then returns the selected credentials as a `Map<String, List<Credential>>`                                                  |
-| signVerifiablePresentation       | SignVerifiablePresentationCallback       | Yes      | N/A              | Callback function to sign the data used for Verifiable Presentation construction. The callback will be invoked with a list of `UnsignedVPToken` to be signed, and the wallet needs to sign each with the appropriate key and return a list of `VPTokenSigningResult`.                                                                                                                                  |
-| openid4vpWalletConfig            | WalletConfig                             | No       | `WalletConfig()` | Configuration passed to the underlying [inji-openid4vp](https://github.com/inji/inji-openid4vp/tree/master/kotlin) library (e.g. supported algorithms / formats). Defaults to the library's default `WalletConfig`.                                                                                                                                                                                  |
+| Name                             | Type                                     | Required    | Default Value  | Description                                                                                                                                        |
+|----------------------------------|------------------------------------------|-------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| openid4vpWalletConfig            | WalletConfig                             | No          | WalletConfig() | Wallet's OpenID4VP related configuration                                                                                                           |
+| selectCredentialsForPresentation | SelectCredentialsForPresentationCallback | Yes         | N/A            | Callback to select credentials from the wallet for the issuer's presentation request                                                               |
+| signVerifiablePresentation       | SignVerifiablePresentationCallback       | Yes         | N/A            | Callback to sign the payload used for verifiable presentation construction                                                                         |
+
 
 
 **Example usage**
-
 ```kotlin
-AuthorizationMethod.PresentationDuringIssuance(
-                            selectCredentialsForPresentation = object : SelectCredentialsForPresentationCallback {
-                                    override suspend fun invoke(
-                                        ovpRequest: AuthorizationRequest
-                                    ): Map<String, List<Credential>> {
-                                        // Handle the logic to select credentials from the wallet as per the presentation request
-                                        // Handle the logic for obtaining consent from the user for presenting the credentials to the issuer
-                                        val selectedCredentials: Map<String, List<Credential>> = selectCredentials(ovpRequest)
-                                        return selectedCredentials
-                                    }
-                                },
-                            signVerifiablePresentation = object : SignVerifiablePresentationCallback {
-                                    override suspend fun invoke(
-                                        payload: List<UnsignedVPToken>
-                                    ): List<VPTokenSigningResult> {
-                                        // Handle the logic to sign the data with the appropriate key as per the credential descriptor and signature suite
-                                        // From each UnsignedVPToken, identify the key and algorithm to be used for signing, sign the data, and return the signature result to the library
-                                        val signedData : List<VPTokenSigningResult> = signDataForVP(payload)
-                                        // since the payload is a list of data to be signed for each credential, the result is also a list containing the signature result for each credential, and the library will take care of constructing the VP with the respective proof for each credential accordingly
-                                        // To avoid any confusion, the library will expect the implementation of this callback to return a list of signature results corresponding to each credential in the same order as the payload, and the library will match the signature result with the respective credential based on the order of the payload list.
-                                        return  signedData
-                                    }
-                            }
-                    )
+AuthorizationMethod.presentationDuringIssuance(
+    openid4vpWalletConfig = openid4vpWalletConfig,
+    selectCredentialsForPresentation = { presentationRequest -> val selectedCredentials: Map<String, List<Credential>> = selectCredentials(presentationRequest)
+        return selectedCredentials
+    },
+    signVerifiablePresentation = { payload -> val signedData: List<VPTokenSigningResult> = signDataForVP(payload)
+        return signedData
+    }
+)
 ```
 
 [//]: # (The branch in inji-wallet for pdi docs link is pointed to master intentionally to ensure that the latest documentation is always referred.)
 > For more details on the Presentation During Issuance flow and the expected implementation of the callbacks, please refer to the [inji-wallet Presentation During Issuance documentation](https://github.com/inji/inji-wallet/blob/master/docs/presentation-during-issuance-support.md)
-
-
-### 3.3 requestCredential (removed in 1.0)
-
-> ⚠️ **Removed in 1.0**: The low-level `requestCredential` method (deprecated since `0.4.0`) and its `IssuerMetaData` DTO have been removed. Please migrate to [`fetchCredentialsUsingCredentialOffer()`](#fetchcredentialsusingcredentialoffer) or [`fetchCredentialsFromTrustedIssuer()`](#fetchcredentialsfromtrustedissuer), which fetch the issuer metadata, build the credential request (for OID4VCI 1.0 or draft 13), and download the credential for you.
-
----
-
-## 🚨 Removed APIs
-
-The following methods (and the `IssuerMetaData` DTO they relied on) were deprecated in earlier releases and have been **removed in 1.0**. Please migrate to the suggested alternatives.
-
-| Method Name                        | Deprecated Since | Removed In | Suggested Alternative                                                                                                                                      |
-|------------------------------------|------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| requestCredentialFromTrustedIssuer | 0.7.0            | 1.0.0      | [fetchCredentialsFromTrustedIssuer](#fetchcredentialsfromtrustedissuer)                                                                                    |
-| requestCredentialByCredentialOffer | 0.7.0            | 1.0.0      | [fetchCredentialsUsingCredentialOffer](#fetchcredentialsusingcredentialoffer)                                                                              |
-| requestCredential                  | 0.4.0            | 1.0.0      | [fetchCredentialsUsingCredentialOffer()](#fetchcredentialsusingcredentialoffer) or [fetchCredentialsFromTrustedIssuer()](#fetchcredentialsfromtrustedissuer) |
 
 ---
 
@@ -439,7 +455,7 @@ The following methods (and the `IssuerMetaData` DTO they relied on) were depreca
 
 -  **PKCE (Proof Key for Code Exchange)** handled internally (RFC 7636)
 -  Supports `S256` code challenge method
--  Secure `nonce` binding via proof JWTs
+-  Secure `c_nonce` binding via proof JWTs
 
 ---
 
@@ -458,8 +474,6 @@ They carry structured fields that help consumers identify whether the failure ca
 | `issuerErrorDescription`  | `String?` | The upstream `error_description` value when available. If the response body is not parseable JSON, the raw response body may be propagated here for diagnostics. |
 
 ### Structured error handling
-
-> New in `1.0.0`: if you are upgrading from `0.7.0`, where only `code` and `message` were reliably available, the structured fields below are new.
 
 The error model exposes the following fields so consumers can react precisely to failures:
 
@@ -500,22 +514,22 @@ try {
         credentialOffer = credentialOffer,
         clientMetadata = clientMetadata,
         getTxCode = getTxCode,
-        authorizations = authorizations,
+        authorizationMethods = authorizationMethods,
         getTokenResponse = getTokenResponse,
         getProofs = getProofs
     )
-} catch (e: VCIClientException) {
+} catch (error: VCIClientException) {
     logger.error(
-        "VCI request failed. code=${e.code}, " +
-            "issuerCode=${e.issuerErrorCode}, issuerDescription=${e.issuerErrorDescription}, " +
-            "message=${e.message}"
+        "VCI request failed. code=${error.code}, " +
+        "issuerCode=${error.issuerErrorCode ?: "nil"}, issuerDescription=${error.issuerErrorDescription ?: "nil"}, " +
+        "message=${error.message}"
     )
 
-    when (e.code) {
-        "VCI-007" -> showRetryMessage()
-        "VCI-003" -> triggerTokenRefresh()
-        "VCI-011" -> showAuthorizationFailure()
-        else -> showGenericFailure()
+    when (error.code) {
+    "VCI-007" -> showRetryMessage()
+    "VCI-003" -> triggerTokenRefresh()
+    "VCI-011" -> showAuthorizationFailure()
+    else -> showGenericFailure()
     }
 }
 ```
@@ -533,9 +547,8 @@ try {
 | VCI-007 | `NetworkRequestTimeoutException`        | Network request timed-out                                                                                |
 | VCI-008 | `CredentialOfferFetchFailedException`   | Failed to fetch credential offer                                                                         |
 | VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata                                                                           |
-| VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                |
+| VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                 |
 | VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
-
 
 ---
 
@@ -547,22 +560,24 @@ Mock-based tests are available covering:
 - Proof JWT signing callbacks
 - Token exchange logic
 
-> See `VCIClientTest` for full coverage
-
-## Platform Support
-
-- **Kotlin:** 1.9+
-- **JVM:** Java 17
-- **Android:** minSdk 23, compileSdk 34
-- **Gradle:** 8.0+
-- **AGP (Android Gradle Plugin):** 8.0+
+> See `VCIClientTests` for full coverage
 
 ## Documentation
 
-- Architecture decisions are documented in the [INJI VCI Client ADR directory](../doc/adr).
-- Documentation of the features are available in the [INJI VCI Client docs directory](../doc).
+- Architecture decisions are documented in the [INJI VCI Client ADR directory](https://github.com/inji/inji-vci-client/tree/master/doc/adr).
+- Documentation of the features are available in the [INJI VCI Client docs directory](https://github.com/inji/inji-vci-client/tree/master/doc).
+- The OpenID4VCI 1.0 migration and Draft-13 compatibility design for this Kotlin library is documented in [ADR-0001](docs/adr/0001-openid4vci-v1-migration.md).
 
-**Note: The iOS (Swift) library is available in the [INJI VCI Client iOS repository](https://github.com/inji/inji-vci-client-ios-swift).**
+**Note: The Android library is available in the [INJI VCI Client repository](https://github.com/inji/inji-vci-client).**
+
+---
+
+## Library Implementations Available In
+
+This library is officially supported and available in both Kotlin and Kotlin, ensuring seamless integration across Android and Android platforms:
+
+* [Kotlin](https://github.com/inji/inji-vci-client/tree/master/kotlin)
+* [Kotlin](.)
 
 ---
 
@@ -570,13 +585,35 @@ Mock-based tests are available covering:
 
 A complete sample app demonstrating credential issuance flows, proof JWT signing, and error handling with `VCIClient` is available here:
 
-[Example Android App](./example)
+[Example Android App Repository](./example)
 
 - Shows both **Credential Offer** and **Trusted Issuer** flows
 - Includes best practices for callbacks and UI integration
+- Can be built and run on Android device only
 
 > Use the example app to quickly get started and see the library in action.
 
 ---
-</content>
-</invoke>
+
+## Migration Guide
+
+For information on upgrading between versions, see the [Migration Guide](docs/migration-guides/MIGRATION_0.7.0_TO_1.0.0.md).
+
+---
+
+## Glossary
+
+* **Credential:** A verifiable piece of information issued by a trusted issuer that can be presented to a verifier.
+* **Verifiable Credential (VC):** A tamper-evident credential with cryptographic proofs of its authenticity and integrity.
+* **Holder / Wallet:** The entity that owns Verifiable Credentials and presents them. This library provides the OID4VCI handling for wallet applications.
+* **Credential Issuer:** A server that issues credentials to wallets following the OID4VCI protocol.
+* **OID4VCI:** OpenID for Verifiable Credential Issuance. A standard protocol for issuing Verifiable Credentials to wallets.
+* **Credential Offer:** A URI or JSON payload sent by the issuer to initiate the credential download flow.
+* **Trusted Issuer:** A wallet-initiated flow where the wallet already knows the issuer and requests a credential directly.
+* **PKCE:** Proof Key for Code Exchange (RFC 7636). A security extension to OAuth 2.0 that prevents authorization code interception.
+* **c_nonce:** A nonce provided by the issuer to be bound into the proof JWT, ensuring the proof is fresh and tied to this issuance session.
+* **Proof JWT:** A signed JWT included in the credential request to prove the wallet controls the key associated with the credential subject.
+* **PDI (Presentation During Issuance):** An authorization flow where the wallet presents an existing credential to the issuer as proof of identity, instead of using a web redirect.
+* **JWT:** JSON Web Token. A digitally signed token format used for secure transmission of claims.
+* **AnyCodable:** A Kotlin type-erased `Codable` wrapper used to represent the credential payload, which may be a JSON object, string, or other format depending on the credential type.
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for upgrading Kotlin integrations from version 0.7.0 to 1.0.0.
  * Updated README documentation for OpenID4VCI 1.0 credential downloads, proof callbacks, PDI support, authorization methods, structured errors, and Draft-13 compatibility.
  * Added architecture decision records covering OpenID4VCI 1.0 migration and VP 1.0 presentation request support.
  * Documented renamed APIs, list-based credential responses, removed legacy interfaces, and revised error-handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->