### PR TITLE
fix(exception): add DPoP exception and illegal-argument error codes with the iOS vci client

### DIFF
--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/VCIClient.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/VCIClient.kt
@@ -11,6 +11,7 @@ import io.mosip.vciclient.constants.TxCodeCallback
 import io.mosip.vciclient.credential.response.CredentialResponse
 import io.mosip.vciclient.credentialOffer.CredentialOfferFlowHandler
 import io.mosip.vciclient.dpop.DPoPManager
+import io.mosip.vciclient.exception.DPoPException
 import io.mosip.vciclient.exception.VCIClientException
 import io.mosip.vciclient.issuerMetadata.IssuerMetadataService
 import io.mosip.vciclient.trustedIssuer.TrustedIssuerFlowHandler
@@ -30,8 +31,16 @@ class VCIClient(val traceabilityId: String) {
     fun generateTokenDPoPProof(dpopNonce: String): String {
         try {
             return dpopManager.generateTokenProof(dpopNonce)
-        } catch (e: IllegalStateException) {
-            throw VCIClientException("VCI-011", "DPoP proof cannot be generated: ${e.message}", cause = e)
+        } catch (e: VCIClientException) {
+            throw VCIClientException(
+                "VCI-010",
+                e.message,
+                cause = e,
+                issuerErrorCode = e.issuerErrorCode,
+                issuerErrorDescription = e.issuerErrorDescription
+            )
+        } catch (e: Exception) {
+            throw DPoPException("DPoP proof cannot be generated: ${e.message}", cause = e)
         }
     }
 

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/dpop/DPoPAlgorithm.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/dpop/DPoPAlgorithm.kt
@@ -14,6 +14,7 @@ import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import io.mosip.vciclient.exception.DPoPException
 import java.util.UUID
 
 private const val RSA_KEY_SIZE = 2048
@@ -74,7 +75,7 @@ internal enum class DPoPAlgorithm(val algorithmName: String, val jwsAlgorithm: J
         fun select(authorizationServerSupported: List<String>?): DPoPAlgorithm {
             if (authorizationServerSupported.isNullOrEmpty()) return DEFAULT
             return preferenceOrder.firstOrNull { it.algorithmName in authorizationServerSupported }
-                ?: throw IllegalArgumentException(
+                ?: throw DPoPException(
                     "No supported DPoP algorithm found. AS supports: $authorizationServerSupported, " +
                     "client supports: ${preferenceOrder.map { it.algorithmName }}"
                 )

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/dpop/DPoPManager.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/dpop/DPoPManager.kt
@@ -7,6 +7,7 @@ import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import io.mosip.vciclient.constants.Constants
+import io.mosip.vciclient.exception.DPoPException
 import java.net.URI
 import java.security.MessageDigest
 import java.util.Date
@@ -31,8 +32,17 @@ class DPoPManager {
 
     fun initialize(tokenEndpoint: String, authorizationServerSupportedAlgorithms: List<String>?) {
         if (session != null) return
-        val algorithm = DPoPAlgorithm.select(authorizationServerSupportedAlgorithms)
-        session = Session(algorithm.generateKey(), algorithm, normalizeHtu(tokenEndpoint))
+        try {
+            val algorithm = DPoPAlgorithm.select(authorizationServerSupportedAlgorithms)
+            session = Session(algorithm.generateKey(), algorithm, normalizeHtu(tokenEndpoint))
+        } catch (e: DPoPException) {
+            throw e
+        } catch (e: Exception) {
+            throw DPoPException(
+                "Unexpected error while initializing the DPoP session: ${e.message}",
+                cause = e
+            )
+        }
     }
 
     fun reset() {
@@ -44,12 +54,31 @@ class DPoPManager {
         if (!nonce.isNullOrBlank()) issuerNonce = nonce
     }
 
-    fun jwkThumbprint(): String =
-        requireSession().key.toPublicJWK().computeThumbprint().toString()
+    fun jwkThumbprint(): String {
+        try {
+            return requireSession().key.toPublicJWK().computeThumbprint().toString()
+        } catch (e: DPoPException) {
+            throw e
+        } catch (e: Exception) {
+            throw DPoPException(
+                "Unexpected error while computing the DPoP JWK thumbprint: ${e.message}",
+                cause = e
+            )
+        }
+    }
 
     fun generateTokenProof(nonce: String? = null): String {
-        val activeSession = requireSession()
-        return buildProof(activeSession, activeSession.tokenEndpoint, nonce, accessToken = null)
+        try {
+            val activeSession = requireSession()
+            return buildProof(activeSession, activeSession.tokenEndpoint, nonce, accessToken = null)
+        } catch (e: DPoPException) {
+            throw e
+        } catch (e: Exception) {
+            throw DPoPException(
+                "Unexpected error while generating the token DPoP proof: ${e.message}",
+                cause = e
+            )
+        }
     }
 
     fun generateCredentialProof(
@@ -57,9 +86,23 @@ class DPoPManager {
         accessToken: String,
         nonce: String? = null,
     ): String {
-        val activeSession = requireSession()
-        updateNonce(nonce)
-        return buildProof(activeSession, normalizeHtu(credentialEndpoint), issuerNonce, accessToken)
+        try {
+            val activeSession = requireSession()
+            updateNonce(nonce)
+            return buildProof(
+                activeSession,
+                normalizeHtu(credentialEndpoint),
+                issuerNonce,
+                accessToken
+            )
+        } catch (e: DPoPException) {
+            throw e
+        } catch (e: Exception) {
+            throw DPoPException(
+                "Unexpected error while generating the credential DPoP proof: ${e.message}",
+                cause = e
+            )
+        }
     }
 
     private fun buildProof(
@@ -98,7 +141,7 @@ class DPoPManager {
     }
 
     private fun requireSession(): Session = session
-        ?: throw IllegalStateException("DPoP session is not initialized for the current flow")
+        ?: throw DPoPException("DPoP session is not initialized for the current flow")
 
     private fun normalizeHtu(endpoint: String): String {
         val uri = URI(endpoint).normalize()

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/DPoPException.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/DPoPException.kt
@@ -1,0 +1,22 @@
+package io.mosip.vciclient.exception
+
+class DPoPException : VCIClientException {
+
+    constructor(message: String?) : super(
+        code = "VCI-013",
+        message = message ?: ""
+    )
+
+    constructor(
+        message: String?,
+        issuerErrorCode: String? = null,
+        issuerErrorDescription: String? = null,
+        cause: Throwable? = null
+    ) : super(
+        code = "VCI-013",
+        message = message ?: "",
+        issuerErrorCode = issuerErrorCode,
+        issuerErrorDescription = issuerErrorDescription,
+        cause = cause
+    )
+}

--- a/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/IllegalArgumentException.kt
+++ b/kotlin/vci-client/src/main/java/io/mosip/vciclient/exception/IllegalArgumentException.kt
@@ -1,0 +1,22 @@
+package io.mosip.vciclient.exception
+
+class IllegalArgumentException : VCIClientException {
+
+    constructor(message: String?) : super(
+        code = "VCI-012",
+        message = message ?: "An illegal argument was provided."
+    )
+
+    constructor(
+        message: String?,
+        issuerErrorCode: String? = null,
+        issuerErrorDescription: String? = null,
+        cause: Throwable? = null
+    ) : super(
+        code = "VCI-012",
+        message = message ?: "An illegal argument was provided.",
+        issuerErrorCode = issuerErrorCode,
+        issuerErrorDescription = issuerErrorDescription,
+        cause = cause
+    )
+}

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/VCIClientTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/VCIClientTest.kt
@@ -307,7 +307,7 @@ class VCIClientTest {
         val exception = assertThrows<VCIClientException> {
             VCIClient("trace-id").generateTokenDPoPProof("nonce")
         }
-        assertEquals("VCI-011", exception.code)
+        assertEquals("VCI-013", exception.code)
     }
 
     @Test

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/dpop/DPoPAlgorithmTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/dpop/DPoPAlgorithmTest.kt
@@ -1,5 +1,6 @@
 package io.mosip.vciclient.dpop
 
+import io.mosip.vciclient.exception.DPoPException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -53,10 +54,11 @@ class DPoPAlgorithmTest {
 
     @Test
     fun `throws when AS advertises only unsupported algorithms`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<DPoPException> {
             DPoPAlgorithm.select(listOf("PS256", "HS256"))
         }
-        assertTrue(exception.message!!.contains("No supported DPoP algorithm found"))
+        assertEquals("VCI-013", exception.code)
+        assertTrue(exception.message.contains("No supported DPoP algorithm found"))
     }
 
     @Test

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/dpop/DPoPManagerTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/dpop/DPoPManagerTest.kt
@@ -10,6 +10,7 @@ import com.nimbusds.jose.jwk.OctetKeyPair
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.SignedJWT
+import io.mosip.vciclient.exception.DPoPException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -226,7 +227,23 @@ class DPoPManagerTest {
 
     @Test
     fun `generate proof throws when session is not initialized`() {
-        assertThrows<IllegalStateException> { DPoPManager().generateTokenProof() }
+        val exception = assertThrows<DPoPException> { DPoPManager().generateTokenProof() }
+        assertEquals("VCI-013", exception.code)
+    }
+
+    @Test
+    fun `jwk thumbprint throws when session is not initialized`() {
+        val exception = assertThrows<DPoPException> { DPoPManager().jwkThumbprint() }
+        assertEquals("VCI-013", exception.code)
+    }
+
+    @Test
+    fun `initialize wraps a non dpop failure as a dpop exception`() {
+        val exception = assertThrows<DPoPException> {
+            DPoPManager().initialize("ht tp://as.example.com/token", listOf("ES256"))
+        }
+        assertEquals("VCI-013", exception.code)
+        assertTrue(exception.message.contains("Unexpected error while initializing the DPoP session"))
     }
 
     @Test

--- a/kotlin/vci-client/src/test/java/io/mosip/vciclient/exception/VCIClientExceptionTest.kt
+++ b/kotlin/vci-client/src/test/java/io/mosip/vciclient/exception/VCIClientExceptionTest.kt
@@ -99,4 +99,51 @@ class VCIClientExceptionTest {
             exception.message
         )
     }
+
+    @Test
+    fun `should construct dpop exception without server details`() {
+        val exception = DPoPException("DPoP session is not initialized for the current flow")
+
+        assertEquals("VCI-013", exception.code)
+        assertNull(exception.issuerErrorCode)
+        assertNull(exception.issuerErrorDescription)
+        assertEquals(
+            "DPoP session is not initialized for the current flow",
+            exception.message
+        )
+    }
+
+    @Test
+    fun `dpop exception retains root code when wrapping a vci exception`() {
+        val exception = DPoPException(
+            message = "Failed to sign DPoP proof: key unusable",
+            cause = InvalidPublicKeyException("unsupported curve")
+        )
+
+        assertEquals("VCI-005", exception.code)
+    }
+
+    @Test
+    fun `should construct illegal argument exception with a default message`() {
+        val exception = IllegalArgumentException(null)
+
+        assertEquals("VCI-012", exception.code)
+        assertNull(exception.issuerErrorCode)
+        assertNull(exception.issuerErrorDescription)
+        assertEquals("An illegal argument was provided.", exception.message)
+    }
+
+    @Test
+    fun `should construct illegal argument exception with server details`() {
+        val exception = IllegalArgumentException(
+            message = "authSession is required",
+            issuerErrorCode = "invalid_request",
+            issuerErrorDescription = "missing authSession"
+        )
+
+        assertEquals("VCI-012", exception.code)
+        assertEquals("invalid_request", exception.issuerErrorCode)
+        assertEquals("missing authSession", exception.issuerErrorDescription)
+        assertEquals("authSession is required", exception.message)
+    }
 }


### PR DESCRIPTION
DPoP failures in the Kotlin client were thrown as bare JDK exceptions, so the download flows caught them in the generic handler and reported `VCI-010` "Unknown Exception" with the cause dropped. The iOS client reports a dedicated code for the same failures, so wallets got different codes per platform.

## Changes

- Add `DPoPException` (`VCI-013`) and `IllegalArgumentException` (`VCI-012`), following the existing exception structure. `VCI-012` matches the code the iOS client already uses.
- Throw `DPoPException` from the DPoP layer: algorithm negotiation, uninitialized session, key generation, JWK thumbprint, and proof signing.
- `VCIClient.generateTokenDPoPProof` now reports `VCI-013` instead of `VCI-011`, and no longer lets a non-`IllegalStateException` escape uncoded.

`VCI-014` is untouched and remains available for the PAR work in #143.

## Tests

`./gradlew :vci-client:test` passes (debug + release). Existing DPoP tests updated to assert the new type and code; added coverage for `DPoPException`, `IllegalArgumentException`, and thumbprint on an uninitialized session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated error handling for DPoP-related failures with consistent error code `VCI-013`.
  * Added structured client argument errors with error code `VCI-012`.
  * Improved error messages and preserved underlying causes for key generation, signing, and algorithm selection failures.

* **Bug Fixes**
  * DPoP failures now retain their specific error type instead of being reported as generic client or state errors.

* **Tests**
  * Expanded coverage for DPoP failures, uninitialized sessions, unsupported algorithms, and exception details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->