### PR TITLE
update workflows to use tagged version of kattu and skip sonar job

### DIFF
--- a/.github/workflows/publish-maven-npm.yml
+++ b/.github/workflows/publish-maven-npm.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   publish-snapshot:
     if: ${{ inputs.release_type == 'snapshot' }}
-    uses: mosip/kattu/.github/workflows/maven-publish-android.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/maven-publish-android.yml@v0.0.1
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'vci-client'
@@ -55,7 +55,7 @@ jobs:
 
   publish-release:
     if: ${{ inputs.release_type == 'release' }}
-    uses: mosip/kattu/.github/workflows/maven-publish-android-download.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/maven-publish-android-download.yml@v0.0.1
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'vci-client'

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -17,20 +17,20 @@ on:
 
 jobs:
   build-kotlin:
-    uses: mosip/kattu/.github/workflows/gradle-build.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/gradle-build.yml@v0.0.1
     with:
       SERVICE_LOCATION: kotlin/vci-client
       JAVA_VERSION: 17
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
 
-  sonar_analysis:
-    needs: build-kotlin
-    if: "${{  github.event_name != 'pull_request' }}"
-    uses: Mahesh-Binayak/kattu/.github/workflows/gradlew-sonar-analysis.yml@sonartest
-    with:
-      SERVICE_LOCATION: kotlin/vci-client
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      ORG_KEY: ${{ secrets.ORG_KEY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
+#  sonar_analysis:
+#    needs: build-kotlin
+#    if: "${{  github.event_name != 'pull_request' }}"
+#    uses: Mahesh-Binayak/kattu/.github/workflows/gradlew-sonar-analysis.yml@sonartest
+#    with:
+#      SERVICE_LOCATION: kotlin/vci-client
+#    secrets:
+#      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#      ORG_KEY: ${{ secrets.ORG_KEY }}
+#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}


### PR DESCRIPTION
update kattu tag and commented sonar job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated publishing workflows to use the stable `v0.0.1` workflow reference.
  * Updated Kotlin build automation to use the stable `v0.0.1` reference.
  * Disabled the Sonar analysis job in the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->