### PR TITLE
bump artifact version to 1.0.0-beta-SNAPSHOT

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -535,6 +535,7 @@ try {
 | VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata                                                                           |
 | VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                |
 | VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
+| VCI-012 | `IllegalArgumentException`              | An illegal argument was provided                                                                         |
 | VCI-013 | `DPoPException`                         | Failed to generate or apply DPoP proof (RFC 9449)                                                        |
 | VCI-014 | `PushedAuthorizationRequestException`   | Failed to push authorization request (RFC 9126)                                                          |
 

--- a/kotlin/vci-client/publish-artifact.gradle
+++ b/kotlin/vci-client/publish-artifact.gradle
@@ -98,7 +98,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "inji-vci-client-aar"
-            version = "1.0.0-alpha.2-SNAPSHOT"
+            version = "1.0.0-beta-SNAPSHOT"
             archivesBaseName = "${artifactId}-${version}"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {


### PR DESCRIPTION
Updates the published artifact version in publish-artifact.gradle from 1.0.0-alpha.2-SNAPSHOT to 1.0.0-beta-SNAPSHOT.
Adds the  VCI-012 (IllegalArgumentException) row to the error code reference table in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error code `VCI-012` for illegal argument failures.

- **Chores**
  - Updated the Android library version to `1.0.0-beta-SNAPSHOT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->