### PR TITLE
refactor: update ovp dependency to 1.0.0-alpha.1

### DIFF
--- a/kotlin/vci-client/build.gradle.kts
+++ b/kotlin/vci-client/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     testImplementation("org.json:json:20231013")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     implementation("com.squareup.okio:okio:3.6.0")
-    implementation("io.inji:inji-openid4vp-aar:1.0.0-alpha.1-SNAPSHOT")
+    implementation("io.inji:inji-openid4vp-aar:1.0.0-alpha.1")
     testImplementation(kotlin("test"))
 }
 


### PR DESCRIPTION
Moves the `inji-openid4vp-aar` dependency off the SNAPSHOT build now that `1.0.0-alpha.1` is published to Maven Central.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Inji OpenID4VP Android library to the stable 1.0.0-alpha.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->